### PR TITLE
AbstractKronecker is not using abstract types anymore

### DIFF
--- a/src/Kronecker.jl
+++ b/src/Kronecker.jl
@@ -1,7 +1,7 @@
 module Kronecker
 
 # TODO types!
-export GeneralizedKroneckerProduct, AbstractKroneckerProduct, SquareKroneckerProduct, EigenKroneckerProduct, ShiftedKroneckerProduct
+export GeneralizedKroneckerProduct, AbstractKroneckerProduct, KroneckerProduct, SquareKroneckerProduct, EigenKroneckerProduct, ShiftedKroneckerProduct
 export issquare, getmatrices, size, getindices, order, issymmetric
 export ⊗, kronecker, Matrix
 export tr, det, collect, inv, *, mult!, eigen, \, /, adjoint, transpose, conj, solve

--- a/src/base.jl
+++ b/src/base.jl
@@ -31,16 +31,18 @@ end
 struct SquareKroneckerProduct{T<:AbstractMatrix, S<:AbstractMatrix} <: AbstractKroneckerProduct
     A::T
     B::S
-    #=function SquareKroneckerProduct{T, S}(A::T, B::S) where {T<:AbstractMatrix, S<:AbstractMatrix}
+    function SquareKroneckerProduct{T,S}(A::T, B::S) where {T<:AbstractMatrix, S<:AbstractMatrix}
         if issquare(A) && issquare(B)
-            return new{T,S}(A, B)
+            return new(A, B)
         else
             throw(DimensionMismatch(
                 "SquareKroneckerProduct is only for when all matrices are square",
             ))
         end
-    end=#
+    end
 end
+
+SquareKroneckerProduct(A::T, B::S) where {T<:AbstractMatrix, S<:AbstractMatrix} = SquareKroneckerProduct{T,S}(A,B);
 
 issquare(K::SquareKroneckerProduct) = true
 LinearAlgebra.:issymmetric(K::SquareKroneckerProduct) = issymmetric(K.A) && issymmetric(K.B)

--- a/src/base.jl
+++ b/src/base.jl
@@ -12,9 +12,9 @@ Matrix(K::GeneralizedKroneckerProduct) = collect(K)
 Base.IndexStyle(::Type{<:GeneralizedKroneckerProduct}) = IndexLinear()
 
 # general Kronecker product between two matrices
-struct KroneckerProduct <: AbstractKroneckerProduct
-    A::AbstractMatrix
-    B::AbstractMatrix
+struct KroneckerProduct{T<:AbstractMatrix, S<:AbstractMatrix} <: AbstractKroneckerProduct
+    A::T
+    B::S
 end
 
 """
@@ -28,18 +28,18 @@ function issquare(A::AbstractMatrix)
 end
 
 # general Kronecker product between two matrices
-struct SquareKroneckerProduct <: AbstractKroneckerProduct
-    A::AbstractMatrix
-    B::AbstractMatrix
-    function SquareKroneckerProduct(A, B)
+struct SquareKroneckerProduct{T<:AbstractMatrix, S<:AbstractMatrix} <: AbstractKroneckerProduct
+    A::T
+    B::S
+    #=function SquareKroneckerProduct{T, S}(A::T, B::S) where {T<:AbstractMatrix, S<:AbstractMatrix}
         if issquare(A) && issquare(B)
-            return new(A, B)
+            return new{T,S}(A, B)
         else
             throw(DimensionMismatch(
                 "SquareKroneckerProduct is only for when all matrices are square",
             ))
         end
-    end
+    end=#
 end
 
 issquare(K::SquareKroneckerProduct) = true


### PR DESCRIPTION
Checking for "squareness" is preserved by adding types and an additional outer constructor

```julia
# general Kronecker product between two matrices
struct SquareKroneckerProduct{T<:AbstractMatrix, S<:AbstractMatrix} <: AbstractKroneckerProduct
    A::T
    B::S
    function SquareKroneckerProduct{T,S}(A::T, B::S) where {T<:AbstractMatrix, S<:AbstractMatrix}
        if issquare(A) && issquare(B)
            return new(A, B)
        else
            throw(DimensionMismatch(
                "SquareKroneckerProduct is only for when all matrices are square",
            ))
        end
    end
end

SquareKroneckerProduct(A::T, B::S) where {T<:AbstractMatrix, S<:AbstractMatrix} = SquareKroneckerProduct{T,S}(A,B);

```
[Reference: Julia Docs](http://web.mit.edu/julia_v0.6.2/julia/share/doc/julia/html/en/manual/constructors.html)

Resolves  #9