### PR TITLE
Define new type KroneckerSum

### DIFF
--- a/src/Kronecker.jl
+++ b/src/Kronecker.jl
@@ -2,8 +2,9 @@ module Kronecker
 
 export GeneralizedKroneckerProduct, AbstractKroneckerProduct, AbstractSquareKronecker
 export SquareKroneckerProduct, EigenKroneckerProduct, ShiftedKroneckerProduct
+export AbstractKroneckerSum, KroneckerSum
 export issquare, getmatrices, size, getindices, order, issymmetric, isposdef
-export ⊗, kronecker, Matrix
+export ⊗, kronecker, Matrix, ⊕, kroneckersum
 export tr, det, logdet, collect, inv, +, *, mult!, eigen, \, /, adjoint, transpose, conj, solve
 export getindex
 export cholesky, CholeskyKronecker
@@ -18,5 +19,6 @@ include("base.jl")
 include("indexedkroncker.jl")
 include("eigen.jl")
 include("factorization.jl")
+include("kroneckersum.jl")
 
 end # module

--- a/src/kroneckersum.jl
+++ b/src/kroneckersum.jl
@@ -11,3 +11,25 @@ struct KroneckerSum{T<:SquareKroneckerProduct, S<:SquareKroneckerProduct}
         return new{typeof(AI),typeof(IB)}(AI, IB)
     end
 end
+
+
+
+order(M::KroneckerSum) = order(M.A) + order(M.B)
+
+"""
+    kroneckersum(A::AbstractMatrix, B::AbstractMatrix)
+
+Construct a sum of Kronecker products between two square matrices and their respective identity matrices.
+Does not evaluate the Kronecker products explicitly.
+"""
+kroneckersum(A::AbstractMatrix, B::AbstractMatrix) = KroneckerSum(A,B)
+
+"""
+    kroneckersum(A::AbstractMatrix, B::AbstractMatrix...)
+
+Higher-order lazy kronecker sum, e.g.
+```
+kroneckersum(A,B,C,D)
+```
+"""
+kroneckersum(A::AbstractMatrix, B::AbstractMatrix...) = kroneckersum(A,kroneckersum(B...))

--- a/src/kroneckersum.jl
+++ b/src/kroneckersum.jl
@@ -88,3 +88,27 @@ function Base.eltype(K::AbstractKroneckerSum)
     A, B = getmatrices(K)
     return promote_type(eltype(A), eltype(B))
 end
+
+# NOTE that K.A and K.B are both SquareKroneckerProducts, not the factor matrices
+LinearAlgebra.tr(K::AbstractKroneckerSum) = tr(K.A) + tr(K.B)
+
+
+function Base.collect(K::AbstractKroneckerSum)
+    return K.A + K.B
+end
+
+
+function Base.adjoint(K::AbstractKroneckerSum)
+    A, B = getmatrices(K)
+    return kroneckersum(A', B')
+end
+
+function Base.transpose(K::AbstractKroneckerSum)
+    A, B = getmatrices(K)
+    return kroneckersum(transpose(A),transpose(B))
+end
+
+function Base.conj(K::AbstractKroneckerSum)
+    A, B = getmatrices(K)
+    return kroneckersum(conj(A), conj(B))
+end

--- a/src/kroneckersum.jl
+++ b/src/kroneckersum.jl
@@ -33,3 +33,29 @@ kroneckersum(A,B,C,D)
 ```
 """
 kroneckersum(A::AbstractMatrix, B::AbstractMatrix...) = kroneckersum(A,kroneckersum(B...))
+
+"""
+    kroneckersum(A::AbstractMatrix, pow::Int)
+
+Kronecker-sum power, computes
+`A ⊕ A ⊕ ... ⊕ A = (A ⊗ I ⊗ ... ⊗ I) + (I ⊗ A ⊗ ... ⊗ I) + ... (I ⊗ I ⊗ ... A)'.
+"""
+function kroneckersum(A::AbstractMatrix, pow::Int)
+    @assert pow > 0 "Works only with positive powers!"
+    if pow == 1
+        return A
+    else
+        return A ⊕ kroneckersum(A, pow-1)
+    end
+end
+
+
+"""
+    ⊕(A::AbstractMatrix, B::AbstractMatrix)
+
+Binary operator for `kroneckersum`, computes as Lazy Kronecker sum. See `kroneckersum` for
+documentation.
+"""
+⊕(A::AbstractMatrix, B::AbstractMatrix) = kroneckersum(A, B)
+
+⊕(A, B) = kroneckersum(A, B)

--- a/src/kroneckersum.jl
+++ b/src/kroneckersum.jl
@@ -1,4 +1,6 @@
-struct KroneckerSum{T<:SquareKroneckerProduct, S<:SquareKroneckerProduct}
+abstract type AbstractKroneckerSum <: GeneralizedKroneckerProduct end
+
+struct KroneckerSum{T<:SquareKroneckerProduct, S<:SquareKroneckerProduct} <: AbstractKroneckerSum
     # Fields
     A::T # (A ⊗ I_B)
     B::S # (I_A ⊗ B)
@@ -13,8 +15,8 @@ struct KroneckerSum{T<:SquareKroneckerProduct, S<:SquareKroneckerProduct}
 end
 
 
-
-order(M::KroneckerSum) = order(M.A) + order(M.B)
+# All products are of same order
+order(M::AbstractKroneckerSum) = order(M.A)
 
 """
     kroneckersum(A::AbstractMatrix, B::AbstractMatrix)
@@ -59,3 +61,10 @@ documentation.
 ⊕(A::AbstractMatrix, B::AbstractMatrix) = kroneckersum(A, B)
 
 ⊕(A, B) = kroneckersum(A, B)
+
+"""
+    getmatrices(K::T) where T <: KroneckerSum
+
+Obtain the two Kronecker products of a `KroneckerSum` object.
+"""
+Kronecker.getmatrices(K::AbstractKroneckerSum) = (Kronecker.getmatrices(K.A)[1], Kronecker.getmatrices(K.B)[2])

--- a/src/kroneckersum.jl
+++ b/src/kroneckersum.jl
@@ -113,18 +113,6 @@ function Base.conj(K::AbstractKroneckerSum)
     return kroneckersum(conj(A), conj(B))
 end
 
-function Base.:*(K1::AbstractKroneckerSum, K2::AbstractKroneckerSum)
-
-    # Collect products (not matrices)
-    A, B = (K1.A, K1.B)
-    C, D = (K2.A, K2.B)
-
-    size.(getmatrices(A)) == size.(getmatrices(C)) || throw(DimensionMismatch("Mismatch between A and C in (A ⊗ B)(C ⊗ D)"))
-    size.(getmatrices(B)) == size.(getmatrices(D)) || throw(DimensionMismatch("Mismatch between B and D in (A ⊗ B)(C ⊗ D)"))
-
-    # Dimensions are also checked in src/base.jl
-    return A*C + A*D + B*C + B*D
-end
 
 
 function LinearAlgebra.mul!(x::AbstractVector, K::AbstractKroneckerSum, v::AbstractVector)

--- a/src/kroneckersum.jl
+++ b/src/kroneckersum.jl
@@ -68,3 +68,23 @@ documentation.
 Obtain the two Kronecker products of a `KroneckerSum` object.
 """
 Kronecker.getmatrices(K::AbstractKroneckerSum) = (Kronecker.getmatrices(K.A)[1], Kronecker.getmatrices(K.B)[2])
+
+function Base.size(K::AbstractKroneckerSum)
+    # All products in sum are the same size
+    size(K.A)
+end
+
+function Base.getindex(K::AbstractKroneckerSum, i1::Int, i2::Int)
+    A, B = (K.A, K.B)
+    m, n = size(A)
+    k, l = size(B)
+    return getindex(A,i1,i2) + getindex(B,i1,i2)
+end
+
+
+Base.size(K::AbstractKroneckerSum, dim::Int) = size(K)[dim]
+
+function Base.eltype(K::AbstractKroneckerSum)
+    A, B = getmatrices(K)
+    return promote_type(eltype(A), eltype(B))
+end

--- a/src/kroneckersum.jl
+++ b/src/kroneckersum.jl
@@ -1,0 +1,13 @@
+struct KroneckerSum{T<:SquareKroneckerProduct, S<:SquareKroneckerProduct}
+    # Fields
+    A::T # (A ⊗ I_B)
+    B::S # (I_A ⊗ B)
+
+    function KroneckerSum(A::AbstractMatrix{T}, B::AbstractMatrix{V}) where {T, V}
+        (issquare(A) && issquare(B)) || throw(DimensionMismatch("KroneckerSum only applies to square matrices"))
+        AI = A ⊗ Diagonal(oneunit(B))
+        IB = Diagonal(oneunit(A)) ⊗ B
+
+        return new{typeof(AI),typeof(IB)}(AI, IB)
+    end
+end

--- a/test/kroneckersum_tests.jl
+++ b/test/kroneckersum_tests.jl
@@ -54,14 +54,6 @@
         @test conj(KS) == conj(kronsum)
     end
 
-
-
-    C = rand(4,4); IC = oneunit(C)
-    D = rand(3,3); ID = oneunit(D)
-    @testset "Mixed-product of sums" begin
-        @test (A ⊕ B)*(C ⊕ D) ≈ (kron(A,IB) + kron(IA,B)) * (kron(C,ID) + kron(IC,D))
-    end
-
     A = rand(10,10); B = rand(10,10); V = Diagonal(rand(10))
     @testset "Vec trick for sums" begin
         @test (A ⊕ B) * vec(V) == vec(B*V + V*transpose(A))

--- a/test/kroneckersum_tests.jl
+++ b/test/kroneckersum_tests.jl
@@ -32,4 +32,16 @@
     @test order(KS) == 2
     @test order(KS3) == 3
 
+    @test getmatrices(KS) == (A,B)
+    @test_broken getmatrices(KS3) == (A,B,C)
+
+    @test getindex(KS,2,3) == kronsum[2,3]
+    @test getindex(KS3,2,3) == kronsum3[2,3]
+
+    D = rand(ComplexF64,6,6)
+    @test size(A ⊕ D) == size(A) .* size(D,1)
+    @test size(B ⊕ C ⊕ D) == size(B) .* size(C) .* size(D)
+    @test eltype(A ⊕ B) == Float64
+    @test eltype(C ⊕ D) == ComplexF64
+
 end

--- a/test/kroneckersum_tests.jl
+++ b/test/kroneckersum_tests.jl
@@ -1,0 +1,35 @@
+@testset "Kronecker sums" begin
+
+
+    A = rand(4,4); IA = oneunit(A)
+    B = rand(3,3); IB = oneunit(B)
+
+    KS = A ⊕ B
+    kronsum = kron(A,IB) + kron(IA,B)
+
+    @testset "A ⊕ B factors" begin
+        @test KS.A isa SquareKroneckerProduct && KS.B isa SquareKroneckerProduct
+        @test KS.A == kronecker(A,IB) && KS.B == kronecker(IA,B)
+    end
+    @test collect(KS) == kronsum
+
+
+
+    C = rand(5,5); IC = oneunit(C)
+    KS3 = A ⊕ B ⊕ C
+    kronsum3 = kron(A,IB,IC) + kron(IA,B,IC) + kron(IA,IB,C)
+
+    @testset "A ⊕ B ⊕ C factors" begin
+        @test KS3.A.A.A.A == A
+        @test KS3.A.A.B.B == B
+        @test KS3.B.B == C
+    end
+
+    # Can't collect higher order sums
+    @test_broken collect(KS3) = kronsum
+
+
+    @test order(KS) == 2
+    @test order(KS3) == 3
+
+end

--- a/test/kroneckersum_tests.jl
+++ b/test/kroneckersum_tests.jl
@@ -38,16 +38,32 @@
     @test getindex(KS,2,3) == kronsum[2,3]
     @test getindex(KS3,2,3) == kronsum3[2,3]
 
-    D = rand(ComplexF64,6,6)
-    @test size(A ⊕ D) == size(A) .* size(D,1)
-    @test size(B ⊕ C ⊕ D) == size(B) .* size(C) .* size(D)
-    @test eltype(A ⊕ B) == Float64
-    @test eltype(C ⊕ D) == ComplexF64
+    D = rand(ComplexF64,6,6); ID = oneunit(D)
+
+    @testset "Structure of sums" begin
+        @test size(A ⊕ D) == size(A) .* size(D,1)
+        @test size(B ⊕ C ⊕ D) == size(B) .* size(C) .* size(D)
+        @test eltype(A ⊕ B) == Float64
+        @test eltype(C ⊕ D) == ComplexF64
+    end
+
+    @testset "Basic linear algebra for sums" begin
+        @test tr(KS) ≈ tr(kronsum)
+        @test KS' == kronsum'
+        @test transpose(KS) == transpose(kronsum)
+        @test conj(KS) == conj(kronsum)
+    end
 
 
-    @test tr(KS) ≈ tr(kronsum)
 
-    @test KS' == kronsum'
-    @test transpose(KS) == transpose(kronsum)
-    @test conj(KS) == conj(kronsum)
+    C = rand(4,4); IC = oneunit(C)
+    D = rand(3,3); ID = oneunit(D)
+    @testset "Mixed-product of sums" begin
+        @test (A ⊕ B)*(C ⊕ D) ≈ (kron(A,IB) + kron(IA,B)) * (kron(C,ID) + kron(IC,D))
+    end
+
+    A = rand(10,10); B = rand(10,10); V = Diagonal(rand(10))
+    @testset "Vec trick for sums" begin
+        @test (A ⊕ B) * vec(V) == vec(B*V + V*transpose(A))
+    end
 end

--- a/test/kroneckersum_tests.jl
+++ b/test/kroneckersum_tests.jl
@@ -44,4 +44,10 @@
     @test eltype(A ⊕ B) == Float64
     @test eltype(C ⊕ D) == ComplexF64
 
+
+    @test tr(KS) ≈ tr(kronsum)
+
+    @test KS' == kronsum'
+    @test transpose(KS) == transpose(kronsum)
+    @test conj(KS) == conj(kronsum)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using Kronecker
 using Test
 using LinearAlgebra
-
 include("testbase.jl")
 include("testindexed.jl")
 #include("testshifted.jl")
+include("kroneckersum_tests.jl")


### PR DESCRIPTION
This PR overloads the binary operator `⊕(A::AbstractMatrix, B::AbstractMatrix)` to calculate the [Kronecker sum](http://mathworld.wolfram.com/KroneckerSum.html) in a similar fashion to `⊗(A::AbstractMatrix, B::AbstractMatrix)` for Kronecker products.


The new `KroneckerSum`-type should store each term as a lazy `SquareKroneckerProduct`. That way, most methods from `src/base.jl` could be reused (except things like `inv` or `det`).
The structure of the file `src/kroneckersum.jl` would be similar to `src/base.jl`.

For higher order sums, I'm having trouble arranging the order of recursive sums as well as `collect`ing the total sum.