### PR TITLE
Test mul! for reshaped arrays

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Kronecker, Test, LinearAlgebra
-using SparseArrays: SparseMatrixCSC
+using SparseArrays: SparseMatrixCSC, sprand
 
 @testset "Kronecker" begin
     include("testbase.jl")

--- a/test/testvectrick.jl
+++ b/test/testvectrick.jl
@@ -33,4 +33,10 @@ end
     @test K * vec(V) ≈ X * vec(V)
     @test_throws DimensionMismatch K * V
     @test_throws DimensionMismatch K * reshape(V, 2, 6)
+    K3 = A ⊗ B ⊗ C
+    v3 = sprand(size(K3, 2),1.0)
+    @test K3 * vec(v3) ≈ collect(K3) * v3
+    u = similar(v)
+    @test mul!(u, K, v) ≈ X * v
+
 end

--- a/test/testvectrick.jl
+++ b/test/testvectrick.jl
@@ -18,3 +18,19 @@
     u = similar(v)
     @test mul!(u, K, v) ≈ X * v
 end
+
+@testset "Reshaped vec trick" begin
+    A = rand(3, 3)
+    B = ones(4, 4)
+    C = randn(5, 6)
+    K = A ⊗ B
+    X = collect(K)
+    v = rand(12)
+
+    @test K * v ≈ X * v
+
+    V = sprand(4, 3, 1.0)
+    @test K * vec(V) ≈ X * vec(V)
+    @test_throws DimensionMismatch K * V
+    @test_throws DimensionMismatch K * reshape(V, 2, 6)
+end


### PR DESCRIPTION
[Coverage shows](https://coveralls.io/jobs/51681653/source_files/1800147847#L50) that tests miss `mul!(...,v::ReshapedArray)`
This PR adds a test for `K * vec(V)` where `vec(V)` does not output an `Array`, but a `ReshapedArray`.