### PR TITLE
Improve adding to a dense matrix

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -224,6 +224,9 @@ Converts a `GeneralizedKroneckerProduct` instance to a Matrix type.
 """
 Base.Matrix(K::GeneralizedKroneckerProduct) = collect(K)
 
+Base.:+(A::AbstractKroneckerProduct, B::StridedMatrix) = Matrix(A) + B
+Base.:+(A::StridedMatrix, B::AbstractKroneckerProduct) = A + Matrix(B)
+
 function Base.kron(K::AbstractKroneckerProduct, C::AbstractMatrix)
     A, B = getmatrices(K)
     return kron(kron(A, B), C)

--- a/src/base.jl
+++ b/src/base.jl
@@ -224,8 +224,12 @@ Converts a `GeneralizedKroneckerProduct` instance to a Matrix type.
 """
 Base.Matrix(K::GeneralizedKroneckerProduct) = collect(K)
 
-Base.:+(A::AbstractKroneckerProduct, B::StridedMatrix) = Matrix(A) + B
-Base.:+(A::StridedMatrix, B::AbstractKroneckerProduct) = A + Matrix(B)
+function Base.:+(A::AbstractKroneckerProduct, B::StridedMatrix)
+    C = Matrix(A)
+    C .+= B
+    return C
+end
+Base.:+(A::StridedMatrix, B::AbstractKroneckerProduct) = B + A
 
 function Base.kron(K::AbstractKroneckerProduct, C::AbstractMatrix)
     A, B = getmatrices(K)

--- a/test/testbase.jl
+++ b/test/testbase.jl
@@ -90,6 +90,11 @@
         @test_throws DimensionMismatch (A ⊗ D) * (C ⊗ B)
     end
 
+    @testset "Add to dense" begin
+        @test K + X ≈ Matrix(K) + X
+        @test X + K ≈ X + Matrix(K)
+    end
+
     @testset "Scalar multiplication" begin
         @test 3.0K ≈ 3.0X
         @test K * 2 ≈ 2X


### PR DESCRIPTION
I've found it's significantly faster when adding a `KroneckerProduct` to a `Matrix` to first fully instantiate the `KroneckerProduct` and then add the dense one to it. This is as opposed to using the default addition implementation from Base, which falls back to indexing over everything.
```julia
using BenchmarkTools, Kronecker

A, B = randn(45, 50), randn(55, 60);
C = A ⊗ B;
D = randn(size(C));
@benchmark $C + $D

# This branch
julia> @benchmark $C + $D
BenchmarkTools.Trial:
  memory estimate:  56.65 MiB
  allocs estimate:  2
  --------------
  minimum time:     20.393 ms (18.29% GC)
  median time:      21.337 ms (20.52% GC)
  mean time:        21.883 ms (22.36% GC)
  maximum time:     75.583 ms (77.89% GC)
  --------------
  samples:          229
  evals/sample:     1

# master
julia> @benchmark $C + $D
BenchmarkTools.Trial:
  memory estimate:  56.65 MiB
  allocs estimate:  2
  --------------
  minimum time:     171.082 ms (2.46% GC)
  median time:      182.415 ms (2.43% GC)
  mean time:        185.580 ms (4.42% GC)
  maximum time:     226.640 ms (22.55% GC)
  --------------
  samples:          27
  evals/sample:     1
```