### PR TITLE
CI Improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,21 @@ codecov: true
 coveralls: true
 
 language: julia
+os:
+  - linux
+  - osx
+  - windows
 julia:
+  - 1.0
+  - 1.2
+  - 1.3
   - nightly
-  - 1.1
-  - 1.0.3
+notifications:
+  email: false
+git:
+  depth: 99999999
+
+matrix:
+ allow_failures:
+ - julia: nightly
+ - julia: 1.3


### PR DESCRIPTION
Sorry for opening yet _another_ PR today. This one tweaks CI to make sure that everything runs on linux, mac os, and windows, and ensures that it runs on all relevant versions of Julia (1.0 being the LTS version, and 1.1 now being officially unsupported). I've allowed failures on 1.3 and nightly as they've not been released yet. Will need to be tweaked as new released happen.