### PR TITLE
Works with NamedDims

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,5 +17,6 @@ Documenter = "~0.23"
 julia = "1"
 
 [extras]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.4.1"
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+NamedDims = "356022a1-0364-5f58-8944-0da4b18d706f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"

--- a/src/Kronecker.jl
+++ b/src/Kronecker.jl
@@ -22,5 +22,6 @@ include("eigen.jl")
 include("factorization.jl")
 include("kroneckersum.jl")
 include("kroneckergraphs.jl")
+include("names.jl")
 
 end # module

--- a/src/names.jl
+++ b/src/names.jl
@@ -1,0 +1,23 @@
+using NamedDims
+
+# Re-wrap with names:
+kronecker(A::NamedDimsArray{L1}, B::NamedDimsArray{L2}) where {L1,L2} =
+    NamedDimsArray(KroneckerProduct(parent(A), parent(B)), kron_names(L1, L2))
+
+kronecker(A::NamedDimsArray{L}, B::AbstractMatrix) where {L} =
+    NamedDimsArray(KroneckerProduct(parent(A), B), kron_names(L, (:_, :_)))
+kronecker(A::AbstractMatrix, B::NamedDimsArray{L}) where {L} =
+    NamedDimsArray(KroneckerProduct(A, parent(B)), kron_names((:_, :_), L))
+
+# Power
+kronecker(A::NamedDimsArray{L}, p::Int) where {L} =
+    NamedDimsArray(kronecker(parent(A), p), kron_names(L, Val(p)))
+
+# Finding the names
+kron_names(left::Tuple, right::Tuple) = map(_join, left, right)
+
+_join(i::Symbol, j::Symbol) = _join(Val(i), Val(j))
+@generated _join(::Val{i}, ::Val{j}) where {i,j} = QuoteNode(Symbol(i, :⊗, j))
+
+kron_names(L::Tuple, ::Val{1}) = L
+kron_names(L::Tuple, ::Val{p}) where {p} = kron_names(kron_names(L,L), Val(p-1))

--- a/src/names.jl
+++ b/src/names.jl
@@ -17,7 +17,7 @@ kronecker(A::NamedDimsArray{L}, p::Int) where {L} =
 kron_names(left::Tuple, right::Tuple) = map(_join, left, right)
 
 _join(i::Symbol, j::Symbol) = _join(Val(i), Val(j))
-@generated _join(::Val{i}, ::Val{j}) where {i,j} = QuoteNode(Symbol(i, :⊗, j))
+@generated _join(::Val{i}, ::Val{j}) where {i,j} = QuoteNode(Symbol(i, :_, j))
 
 kron_names(L::Tuple, ::Val{1}) = L
 kron_names(L::Tuple, ::Val{p}) where {p} = kron_names(kron_names(L,L), Val(p-1))

--- a/src/names.jl
+++ b/src/names.jl
@@ -17,7 +17,7 @@ kronecker(A::NamedDimsArray{L}, p::Int) where {L} =
 kron_names(left::Tuple, right::Tuple) = map(_join, left, right)
 
 _join(i::Symbol, j::Symbol) = _join(Val(i), Val(j))
-@generated _join(::Val{i}, ::Val{j}) where {i,j} = QuoteNode(Symbol(i, :_, j))
+@generated _join(::Val{i}, ::Val{j}) where {i,j} = QuoteNode(Symbol(i, :ᵡ, j))
 
 kron_names(L::Tuple, ::Val{1}) = L
 kron_names(L::Tuple, ::Val{p}) where {p} = kron_names(kron_names(L,L), Val(p-1))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using SparseArrays: SparseMatrixCSC, sprand, AbstractSparseMatrix
 @testset "Kronecker" begin
     include("testbase.jl")
     include("testkroneckerpowers.jl")
+    include("testnames.jl")
     include("testvectrick.jl")
     include("testindexed.jl")
     include("testeigen.jl")

--- a/test/testnames.jl
+++ b/test/testnames.jl
@@ -2,18 +2,18 @@ using NamedDims
 @testset "named" begin
     A = rand(Int8, 2,2)
     B = rand(Int8, 3,3)
-    ndA = NamedDimsArray(A, (:xA, :yA))
-    ndB = NamedDimsArray(B, (:xB, :yB))
+    ndA = NamedDimsArray(A, (:ia, :ja))
+    ndB = NamedDimsArray(B, (:ib, :jb))
 
-    @test NamedDims.names(kronecker(ndA, ndB)) == (Symbol("xA_xB"), Symbol("yA_yB"))
-    @test NamedDims.names(kronecker(ndA, B)) == (Symbol("xA__"), Symbol("yA__"))
-    @test NamedDims.names(kronecker(A, ndB)) == (Symbol("__xB"), Symbol("__yB"))
+    @test NamedDims.names(kronecker(ndA, ndB)) == (Symbol("iaᵡib"), Symbol("jaᵡjb"))
+    @test NamedDims.names(kronecker(ndA, B)) == (Symbol("iaᵡ_"), Symbol("jaᵡ_"))
+    @test NamedDims.names(kronecker(A, ndB)) == (Symbol("_ᵡib"), Symbol("_ᵡjb"))
 
     sum(abs2, kronecker(ndA, ndB) .- kron(A, B)) == 0
 
     @test 0 == @allocated Kronecker._join(:i, :j)
-    @test 0 == @allocated Kronecker.kron_names((:xA, :yA), (:xB, :yB))
+    @test 0 == @allocated Kronecker.kron_names((:ia, :ja), (:ib, :jb))
 
-    @test NamedDims.names(kronecker(ndA, 3)) == (Symbol("xA_xA_xA_xA"), Symbol("yA_yA_yA_yA"))
+    @test NamedDims.names(kronecker(ndA, 3)) == (Symbol("iaᵡiaᵡiaᵡia"), Symbol("jaᵡjaᵡjaᵡja"))
     @test 0 == @allocated Kronecker.kron_names((:i, :j), Val(3))
 end

--- a/test/testnames.jl
+++ b/test/testnames.jl
@@ -1,0 +1,19 @@
+using NamedDims
+@testset "named" begin
+    A = rand(Int8, 2,2)
+    B = rand(Int8, 3,3)
+    ndA = NamedDimsArray(A, (:xA, :yA))
+    ndB = NamedDimsArray(B, (:xB, :yB))
+
+    @test NamedDims.names(kronecker(ndA, ndB)) == (Symbol("xA⊗xB"), Symbol("yA⊗yB"))
+    @test NamedDims.names(kronecker(ndA, B)) == (Symbol("xA⊗_"), Symbol("yA⊗_"))
+    @test NamedDims.names(kronecker(A, ndB)) == (Symbol("_⊗xB"), Symbol("_⊗yB"))
+
+    sum(abs2, kronecker(ndA, ndB) .- kron(A, B)) == 0
+
+    @test 0 == @allocated Kronecker._join(:i, :j)
+    @test 0 == @allocated Kronecker.kron_names((:xA, :yA), (:xB, :yB))
+
+    @test NamedDims.names(kronecker(ndA, 3)) == (Symbol("xA⊗xA⊗xA⊗xA"), Symbol("yA⊗yA⊗yA⊗yA"))
+    @test 0 == @allocated Kronecker.kron_names((:i, :j), Val(3))
+end

--- a/test/testnames.jl
+++ b/test/testnames.jl
@@ -5,15 +5,15 @@ using NamedDims
     ndA = NamedDimsArray(A, (:xA, :yA))
     ndB = NamedDimsArray(B, (:xB, :yB))
 
-    @test NamedDims.names(kronecker(ndA, ndB)) == (Symbol("xA⊗xB"), Symbol("yA⊗yB"))
-    @test NamedDims.names(kronecker(ndA, B)) == (Symbol("xA⊗_"), Symbol("yA⊗_"))
-    @test NamedDims.names(kronecker(A, ndB)) == (Symbol("_⊗xB"), Symbol("_⊗yB"))
+    @test NamedDims.names(kronecker(ndA, ndB)) == (Symbol("xA_xB"), Symbol("yA_yB"))
+    @test NamedDims.names(kronecker(ndA, B)) == (Symbol("xA__"), Symbol("yA__"))
+    @test NamedDims.names(kronecker(A, ndB)) == (Symbol("__xB"), Symbol("__yB"))
 
     sum(abs2, kronecker(ndA, ndB) .- kron(A, B)) == 0
 
     @test 0 == @allocated Kronecker._join(:i, :j)
     @test 0 == @allocated Kronecker.kron_names((:xA, :yA), (:xB, :yB))
 
-    @test NamedDims.names(kronecker(ndA, 3)) == (Symbol("xA⊗xA⊗xA⊗xA"), Symbol("yA⊗yA⊗yA⊗yA"))
+    @test NamedDims.names(kronecker(ndA, 3)) == (Symbol("xA_xA_xA_xA"), Symbol("yA_yA_yA_yA"))
     @test 0 == @allocated Kronecker.kron_names((:i, :j), Val(3))
 end


### PR DESCRIPTION
This adds definitions to work with  https://github.com/invenia/NamedDims.jl. The names of `A` & `B` get combined with `⊗`, which may be a terrible choice as this isn’t printed so nicely: `_join(:i, :j) == Symbol("i⊗j”)`. Perhaps something letterlike would be better. 

This may or may not close #51, which suggests you want not just dimension names but index labels along them.