### PR TITLE
Efficient backslash solve for Kronecker systems

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -309,9 +309,8 @@ function Base.:*(K::AbstractKroneckerProduct, a::Number)
 end
 
 # SOLVING
-using LinearAlgebra: checksquare
 function LinearAlgebra.:\(K::AbstractKroneckerProduct{T}, c::AbstractVector{T}) where {T}
-    size(K, 2) != length(c) && throw(DimensionMismatch("size(K, 2) != length(c)"))
+    size(K, 1) != length(c) && throw(DimensionMismatch("size(K, 1) != length(c)"))
     C = reshape(c, size(K.B, 1), size(K.A, 1)) # matricify
     return vec((K.B \ C) / K.A') #(A ⊗ B)vec(X) = vec(C) <=> BXA' = C => X = B^{-1} C A'^{-1}
 end

--- a/src/base.jl
+++ b/src/base.jl
@@ -307,3 +307,13 @@ function Base.:*(K::AbstractKroneckerProduct, a::Number)
     A, B = getmatrices(K)
     kronecker(A, B * a)
 end
+
+# SOLVING
+using LinearAlgebra: checksquare
+function LinearAlgebra.:\(K::AbstractKroneckerProduct{T}, c::AbstractVector{T}) where {T}
+    !issquare(K.A) && throw(DimensionMismatch("matrix A is not square: dimensions are " * size(K.A)))
+    !issquare(K.B) && throw(DimensionMismatch("matrix B is not square: dimensions are " * size(K.B)))
+    size(K, 2) != length(c) && throw(DimensionMismatch("size(K, 2) != length(c)"))
+    C = reshape(c, size(K.B, 1), size(K.A, 1)) # matricify
+    return vec((K.B \ C) / K.A') #(A ⊗ B)vec(X) = vec(C) <=> BXA' = C => X = B^{-1} C A'^{-1}
+end

--- a/src/base.jl
+++ b/src/base.jl
@@ -311,9 +311,14 @@ end
 # SOLVING
 using LinearAlgebra: checksquare
 function LinearAlgebra.:\(K::AbstractKroneckerProduct{T}, c::AbstractVector{T}) where {T}
-    !issquare(K.A) && throw(DimensionMismatch("matrix A is not square: dimensions are " * size(K.A)))
-    !issquare(K.B) && throw(DimensionMismatch("matrix B is not square: dimensions are " * size(K.B)))
     size(K, 2) != length(c) && throw(DimensionMismatch("size(K, 2) != length(c)"))
-    C = reshape(c, size(K.B, 1), size(K.A, 1)) # matricify
-    return vec((K.B \ C) / K.A') #(A ⊗ B)vec(X) = vec(C) <=> BXA' = C => X = B^{-1} C A'^{-1}
+    if !(issquare(K.A) && issquare(K.B))
+        return Matrix(K)\c
+    else
+        C = reshape(c, size(K.B, 1), size(K.A, 1)) # matricify
+        return vec((K.B \ C) / K.A') #(A ⊗ B)vec(X) = vec(C) <=> BXA' = C => X = B^{-1} C A'^{-1}
+    end
 end
+
+# !issquare(K.A) && throw(DimensionMismatch("matrix A is not square: dimensions are " * size(K.A)))
+# !issquare(K.B) && throw(DimensionMismatch("matrix B is not square: dimensions are " * size(K.B)))

--- a/src/base.jl
+++ b/src/base.jl
@@ -312,13 +312,6 @@ end
 using LinearAlgebra: checksquare
 function LinearAlgebra.:\(K::AbstractKroneckerProduct{T}, c::AbstractVector{T}) where {T}
     size(K, 2) != length(c) && throw(DimensionMismatch("size(K, 2) != length(c)"))
-    if !(issquare(K.A) && issquare(K.B))
-        return Matrix(K)\c
-    else
-        C = reshape(c, size(K.B, 1), size(K.A, 1)) # matricify
-        return vec((K.B \ C) / K.A') #(A ⊗ B)vec(X) = vec(C) <=> BXA' = C => X = B^{-1} C A'^{-1}
-    end
+    C = reshape(c, size(K.B, 1), size(K.A, 1)) # matricify
+    return vec((K.B \ C) / K.A') #(A ⊗ B)vec(X) = vec(C) <=> BXA' = C => X = B^{-1} C A'^{-1}
 end
-
-# !issquare(K.A) && throw(DimensionMismatch("matrix A is not square: dimensions are " * size(K.A)))
-# !issquare(K.B) && throw(DimensionMismatch("matrix B is not square: dimensions are " * size(K.B)))

--- a/test/testbase.jl
+++ b/test/testbase.jl
@@ -132,5 +132,14 @@
         x = randn(n_a * n_b)
         @test K\(K*x) ≈ x
         @test (x'*K)/K ≈ x'
+
+        # testing for non-square A, B
+        A = randn(n_b, n_a)
+        B = randn(n_a, n_b)
+        K = A ⊗ B
+        x = randn(n_a * n_b)
+        c = (K*x)
+        xls = K\c
+        @test K'*(K*xls) ≈ K'c # test via normal equations
     end
 end

--- a/test/testbase.jl
+++ b/test/testbase.jl
@@ -122,4 +122,15 @@
         @test K.B ≈ 2B
         @test K ≈ 6kron(A, B)
     end
+
+    @testset "Solving Linear Systems" begin
+        n_a = 2
+        n_b = 3
+        A = randn(n_a, n_a)
+        B = randn(n_b, n_b)
+        K = A ⊗ B
+        x = randn(n_a * n_b)
+        @test K\(K*x) ≈ x
+        @test (x'*K)/K ≈ x'
+    end
 end

--- a/test/testbase.jl
+++ b/test/testbase.jl
@@ -124,8 +124,8 @@
     end
 
     @testset "Solving Linear Systems" begin
-        n_a = 2
-        n_b = 3
+        n_a = 8
+        n_b = 16
         A = randn(n_a, n_a)
         B = randn(n_b, n_b)
         K = A ⊗ B
@@ -139,6 +139,7 @@
         K = A ⊗ B
         x = randn(n_a * n_b)
         c = (K*x)
+        c .+= randn(size(c)) # this moves c out of range(K), necessitating least-squares
         xls = K\c
         @test K'*(K*xls) ≈ K'c # test via normal equations
     end


### PR DESCRIPTION
I implemented a backslash method for Kronecker systems. 
You can test the speed by trying 
```
n = 32
m = 32
A = randn(n,n);
B = randn(m,m);
K = kronecker(A,B);
c = randn(n*m);
M = Matrix(K);
@time K\c;
@time M\c;
```
Compared to the naive method, I get a speed-up of 2-3 orders of magnitude on my computer for this example.