### PR TITLE
Non-square component matrices

### DIFF
--- a/src/Kronecker.jl
+++ b/src/Kronecker.jl
@@ -13,6 +13,7 @@ using LinearAlgebra, FillArrays
 import LinearAlgebra: mul!, lmul!, rmul!
 import Base: collect, *, getindex, size, eltype, inv, adjoint
 using SparseArrays: sparse
+using LinearAlgebra: checksquare
 
 include("base.jl")
 include("kroneckerpowers.jl")

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -48,7 +48,7 @@ on the matrices of a `AbstractKroneckerProduct` instances and returns a
 and `logdet` are overloaded to efficiently work with this type.
 """
 function cholesky(K::AbstractKroneckerProduct; check = true)
-    squarecheck(K)
+    checksquare(K)
     A, B = getmatrices(K)
     return CholeskyKronecker(cholesky(A, check=check),
                             cholesky(B, check=check))

--- a/src/kroneckerpowers.jl
+++ b/src/kroneckerpowers.jl
@@ -55,7 +55,7 @@ issquare(K::KroneckerPower) = issquare(K.A)
 Compute the determinant of a Kronecker power.
 """
 function LinearAlgebra.det(K::KroneckerPower)
-    squarecheck(K)
+    checksquare(K.A)
     A, pow = K.A, K.pow
     n = size(A, 1)
     return det(K.A)^(n * pow)
@@ -67,7 +67,7 @@ end
 Compute the logarithm of the determinant of a Kronecker power.
 """
 function LinearAlgebra.logdet(K::KroneckerPower)
-    squarecheck(K)
+    checksquare(K.A)
     A, pow = K.A, K.pow
     n = size(A, 1)
     return n * pow * logdet(K.A)
@@ -79,7 +79,7 @@ end
 Compute the trace of a Kronecker power.
 """
 function LinearAlgebra.tr(K::KroneckerPower)
-    squarecheck(K)
+    checksquare(K.A)
     return tr(K.A)^K.pow
 end
 
@@ -91,7 +91,7 @@ end
 Compute the inverse of a Kronecker power.
 """
 function Base.inv(K::KroneckerPower)
-    squarecheck(K)
+    checksquare(K.A)
     return KroneckerPower(inv(K.A), K.pow)
 end
 

--- a/test/testbase.jl
+++ b/test/testbase.jl
@@ -38,6 +38,36 @@
         @test K isa AbstractMatrix{Float64}
     end
 
+    # testing all linear algebra functions' behavior on square and non-square matrices
+    function test_non_square_extensions()
+        local n, m, A, B, K, M
+        n, m = 3, 5
+        # 1. K is square, while A, B aren't
+        A = randn(n, m)
+        B = randn(m, n)
+        K = A ⊗ B
+        M = Matrix(K)
+        @test tr(K) ≈ tr(M)
+        @test det(K) ≈ 0
+        @test logdet(K) ≈ -Inf
+        @test !isposdef(K)
+        @test !issymmetric(K)
+        @test LinearAlgebra.checksquare(K) == size(K, 1) # should not throw on square matrix
+        @test_throws SingularException inv(K) # if K is square but singular
+
+        # 2. K is not square
+        A = randn(n, m)
+        B = randn(m, m)
+        K = A ⊗ B
+        @test !isposdef(K)
+        @test !issymmetric(K)
+        @test_throws DimensionMismatch tr(K)
+        @test_throws DimensionMismatch det(K)
+        @test_throws DimensionMismatch logdet(K)
+        @test_throws DimensionMismatch LinearAlgebra.checksquare(K)
+        @test_throws DimensionMismatch inv(K)
+    end
+
     @testset "Linear algebra" begin
         @test tr(K) ≈ tr(X)
         @test det(K) ≈ det(X)
@@ -51,6 +81,8 @@
         As = A' * A
         Bs = B * B'
         @test logdet(As ⊗ Bs) ≈ log(det(As ⊗ Bs)) ≈ log(det(kron(As, Bs)))
+
+        test_non_square_extensions()
     end
 
     @testset "Mismatch errors" begin

--- a/test/testeigen.jl
+++ b/test/testeigen.jl
@@ -37,4 +37,26 @@ end
     eigen_tests(rng, kronecker(C, D))
     eigen_tests(rng, kronecker(kronecker(A, B), kronecker(B, A)))
     eigen_tests(rng, kronecker(A, 4))
+
+    function test_non_square_extension()
+        local n, m, A, B, K, M
+        n, m = 3, 5
+        # 1. K is square, while A, B aren't
+        A = randn(n, m)
+        B = randn(m, n)
+        K = A ⊗ B
+        M = Matrix(K)
+        E = eigen(K)
+        F = eigen(M)
+        @test E.values ≈ F.values
+        @test det(E) ≈ det(F)
+        @test Matrix(E) ≈ K
+
+        # 2. K is not square
+        A = randn(n, m)
+        B = randn(m, m)
+        K = A ⊗ B
+        @test_throws DimensionMismatch eigen(K)
+    end
+    test_non_square_extension()
 end


### PR DESCRIPTION
As pointed out in my [comment](https://github.com/MichielStock/Kronecker.jl/pull/56#issuecomment-554498916) yesterday, many methods throw `DimensionMismatch` errors, even if the operations they represent are well defined. To change that, this PR makes the following additions:

1. `tr`, `det`, `logdet` now work correctly on square Kronecker products with non-square components A, B
2. `isposdef`, `issymmetric` now don't throw errors on non-square inputs, just like the methods in LinearAlgebra
3. `inv` now throws a SingularException if the components are not square, but the Kronecker product is
4. `eigen` now works on square Kronecker products with non-square components.
5.  `squarecheck` got replaced by the generic `LinearAlgebra.checksquare`
6. The `det` method in eigen was not necessary
7.  I added tests for all of the above

Looking forward to your feedback!

