### PR TITLE
sparse(K::KroneckerSum) returns a KroneckerSum of sparse matrices

### DIFF
--- a/src/Kronecker.jl
+++ b/src/Kronecker.jl
@@ -12,7 +12,7 @@ export isprob, naivesample, fastsample, sampleindices
 using LinearAlgebra, FillArrays
 import LinearAlgebra: mul!, lmul!, rmul!
 import Base: collect, *, getindex, size, eltype, inv, adjoint
-using SparseArrays: sparse
+using SparseArrays
 using LinearAlgebra: checksquare
 
 include("base.jl")

--- a/src/kroneckersum.jl
+++ b/src/kroneckersum.jl
@@ -120,11 +120,11 @@ end
 Creates a lazy instance of a `KroneckerSum` type with sparse
 matrices. If the matrices are already sparse, `K` is returned.
 """
-function SparseArrays.sparse(K::KroneckerSum{T, TA, TB}) where {T <: Any, TA <: AbstractSparseMatrix, TB <: AbstractSparseMatrix}
+function SparseArrays.sparse(K::KroneckerSum{T, TA, TB}) where {T, TA <: AbstractSparseMatrix, TB <: AbstractSparseMatrix}
     return K
 end
 
-function SparseArrays.sparse(K::KroneckerSum{T, TA, TB}) where {T <: Any, TA <: AbstractMatrix, TB <: AbstractMatrix}
+function SparseArrays.sparse(K::KroneckerSum{T, TA, TB}) where {T, TA <: AbstractMatrix, TB <: AbstractMatrix}
     return sparse(K.A) ⊕ sparse(K.B)
 end
 

--- a/src/kroneckersum.jl
+++ b/src/kroneckersum.jl
@@ -108,10 +108,11 @@ end
     collect(K::AbstractKroneckerSum)
 
 Collects a lazy instance of the `AbstractKroneckerSum` type into a full,
-native matrix.
+native matrix. Returns the result as a sparse matrix.
 """
 function Base.collect(K::AbstractKroneckerSum)
     A, B = getmatrices(K)
+    #A, B = sparse(A), sparse(B)
     IA, IB = oneunit(A), oneunit(B)
     return kron(A, IB) + kron(IA, B)
 end

--- a/src/kroneckersum.jl
+++ b/src/kroneckersum.jl
@@ -111,8 +111,7 @@ Collects a lazy instance of the `AbstractKroneckerSum` type into a full,
 native matrix. Returns the result as a sparse matrix.
 """
 function Base.collect(K::AbstractKroneckerSum)
-    A, B = getmatrices(K)
-    #A, B = sparse(A), sparse(B)
+    A, B = getmatrices(sparse(K))
     IA, IB = oneunit(A), oneunit(B)
     return kron(A, IB) + kron(IA, B)
 end

--- a/src/kroneckersum.jl
+++ b/src/kroneckersum.jl
@@ -116,6 +116,27 @@ function Base.collect(K::AbstractKroneckerSum)
     return kron(A, IB) + kron(IA, B)
 end
 
+
+
+
+"""
+    SparseArrays.sparse(K::KroneckerSum)
+
+Creates a lazy instance of a `KroneckerSum` type with sparse
+matrices. If the matrices are already sparse, `K` is returned.
+"""
+function SparseArrays.sparse(K::KroneckerSum{T, TA, TB}) where {T <: Any, TA <: AbstractSparseMatrix, TB <: AbstractSparseMatrix}
+    return K
+end
+
+function SparseArrays.sparse(K::KroneckerSum{T, TA, TB}) where {T <: Any, TA <: AbstractMatrix, TB <: AbstractMatrix}
+    return sparse(K.A) ⊕ sparse(K.B)
+end
+
+function SparseArrays.issparse(K::AbstractKroneckerSum)
+    return issparse(K.A) && issparse(K.B)
+end
+
 function Base.kron(K::AbstractKroneckerSum, C::AbstractMatrix)
     return kron(collect(K), C)
 end

--- a/src/kroneckersum.jl
+++ b/src/kroneckersum.jl
@@ -75,7 +75,6 @@ end
 
 Base.size(K::AbstractKroneckerSum, dim::Int) = size(K)[dim]
 
-
 function Base.getindex(K::AbstractKroneckerSum, i1::Int, i2::Int)
     A, B = getmatrices(K)
     m, n = size(A)
@@ -103,7 +102,6 @@ function LinearAlgebra.tr(K::AbstractKroneckerSum)
     return m * tr(A) + n * tr(B)
 end
 
-
 """
     collect(K::AbstractKroneckerSum)
 
@@ -115,9 +113,6 @@ function Base.collect(K::AbstractKroneckerSum)
     IA, IB = oneunit(A), oneunit(B)
     return kron(A, IB) + kron(IA, B)
 end
-
-
-
 
 """
     SparseArrays.sparse(K::KroneckerSum)

--- a/src/kroneckersum.jl
+++ b/src/kroneckersum.jl
@@ -117,17 +117,16 @@ function Base.collect(K::AbstractKroneckerSum)
 end
 
 function Base.kron(K::AbstractKroneckerSum, C::AbstractMatrix)
-    A, B = getmatrices(K)
-    IA, IB = oneunit(A), oneunit(B)
-    return kron(kron(A, IB) + kron(IA,B), C)
+    return kron(collect(K), C)
 end
 
 function Base.kron(A::AbstractMatrix, K::AbstractKroneckerSum)
-    B, C = getmatrices(K)
-    IB, IC = oneunit(B), oneunit(C)
-    return kron(A, kron(B, IC) + kron(IB, C))
+    return kron(A, collect(K))
 end
 
+function Base.kron(K1::AbstractKroneckerSum, K2:: AbstractKroneckerSum)
+    return kron(collect(K1), collect(K2))
+end
 
 function Base.adjoint(K::AbstractKroneckerSum)
     A, B = getmatrices(K)

--- a/src/kroneckersum.jl
+++ b/src/kroneckersum.jl
@@ -128,6 +128,11 @@ function SparseArrays.sparse(K::KroneckerSum{T, TA, TB}) where {T, TA <: Abstrac
     return sparse(K.A) ⊕ sparse(K.B)
 end
 
+"""
+    SparseArrays.issparse(K::AbstractKroneckerSum)
+
+Checks if both matrices of an `AbstractKroneckerSum` are sparse.
+"""
 function SparseArrays.issparse(K::AbstractKroneckerSum)
     return issparse(K.A) && issparse(K.B)
 end

--- a/src/kroneckersum.jl
+++ b/src/kroneckersum.jl
@@ -75,6 +75,7 @@ end
 
 Base.size(K::AbstractKroneckerSum, dim::Int) = size(K)[dim]
 
+
 function Base.getindex(K::AbstractKroneckerSum, i1::Int, i2::Int)
     A, B = getmatrices(K)
     m, n = size(A)
@@ -102,6 +103,7 @@ function LinearAlgebra.tr(K::AbstractKroneckerSum)
     return m * tr(A) + n * tr(B)
 end
 
+
 """
     collect(K::AbstractKroneckerSum)
 
@@ -110,10 +112,23 @@ native matrix. Returns the result as a sparse matrix.
 """
 function Base.collect(K::AbstractKroneckerSum)
     A, B = getmatrices(K)
-    A, B = sparse(A), sparse(B)
+    #A, B = sparse(A), sparse(B)
     IA, IB = oneunit(A), oneunit(B)
     return kron(A, IB) + kron(IA, B)
 end
+
+function Base.kron(K::AbstractKroneckerSum, C::AbstractMatrix)
+    A, B = getmatrices(K)
+    IA, IB = oneunit(A), oneunit(B)
+    return kron(kron(A, IB) + kron(IA,B), C)
+end
+
+function Base.kron(A::AbstractMatrix, K::AbstractKroneckerSum)
+    B, C = getmatrices(K)
+    IB, IC = oneunit(B), oneunit(C)
+    return kron(A, kron(B, IC) + kron(IB, C))
+end
+
 
 function Base.adjoint(K::AbstractKroneckerSum)
     A, B = getmatrices(K)

--- a/src/kroneckersum.jl
+++ b/src/kroneckersum.jl
@@ -108,11 +108,10 @@ end
     collect(K::AbstractKroneckerSum)
 
 Collects a lazy instance of the `AbstractKroneckerSum` type into a full,
-native matrix. Returns the result as a sparse matrix.
+native matrix.
 """
 function Base.collect(K::AbstractKroneckerSum)
     A, B = getmatrices(K)
-    #A, B = sparse(A), sparse(B)
     IA, IB = oneunit(A), oneunit(B)
     return kron(A, IB) + kron(IA, B)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Kronecker, Test, LinearAlgebra, Random, FillArrays
-using SparseArrays: SparseMatrixCSC, sprand, AbstractSparseMatrix
+using SparseArrays: AbstractSparseMatrix, SparseMatrixCSC, sprand,
+    sparse, issparse
 
 @testset "Kronecker" begin
     include("testbase.jl")

--- a/test/testkroneckersum.jl
+++ b/test/testkroneckersum.jl
@@ -18,7 +18,7 @@
         @test !isa(KS, AbstractKroneckerProduct)
 
         @test collect(KS) ≈ kronsum
-        @test collect(KS) isa arraytype
+        @test collect(KS) isa AbstractSparseMatrix
 
         @test issquare(KS)
 

--- a/test/testkroneckersum.jl
+++ b/test/testkroneckersum.jl
@@ -97,6 +97,15 @@
                 end
             end
         end
+
+        @testset "call kron on Kronecker sums" begin
+            for ks in (KS, KS3, KS3AB, KS3BC)
+                cks = collect(ks)
+                @test kron(ks,D) ≈ kron(cks, D)
+                @test kron(D,ks) ≈ kron(D,cks)
+                @test kron(ks,ks) ≈ kron(cks, cks)
+            end
+        end
     end
 
 end

--- a/test/testkroneckersum.jl
+++ b/test/testkroneckersum.jl
@@ -31,7 +31,7 @@
 
         for ks3 in [KS3, KS3AB, KS3BC]
             @test collect(ks3) ≈ kronsum3
-            @test collect(ks3) isa arraytype
+            @test collect(ks3) isa AbstractSparseMatrix
             @test order(ks3) == 3
             @test getindex(ks3,2,3) == kronsum3[2,3]
         end

--- a/test/testkroneckersum.jl
+++ b/test/testkroneckersum.jl
@@ -82,6 +82,21 @@
             @test_throws ArgumentError sum(KS, dims=-1)
             @test_throws ArgumentError sum(KS3, dims=3)
         end
+
+        @testset "sparse Kronecker sum" begin
+            for ks in (KS, KS3, KS3AB, KS3BC)
+                sks = sparse(ks)
+                @test sks isa AbstractKroneckerSum
+                @test issparse(sks.A)
+                @test issparse(sks.B)
+
+                if arraytype <: Array
+                    @test !issparse(ks)
+                elseif arraytype <: AbstractSparseMatrix
+                    @test issparse(ks)
+                end
+            end
+        end
     end
 
 end

--- a/test/testkroneckersum.jl
+++ b/test/testkroneckersum.jl
@@ -24,9 +24,9 @@
 
         IC = oneunit(C)
         KS3 = A ⊕ B ⊕ C
-        KS3AB = (A ⊕ B) ⊕ C 
+        KS3AB = (A ⊕ B) ⊕ C
         KS3BC = A ⊕ (B ⊕ C)
-        
+
         kronsum3 = kron(A,IB,IC) + kron(IA,B,IC) + kron(IA,IB,C)
 
         for ks3 in [KS3, KS3AB, KS3BC]
@@ -35,11 +35,10 @@
             @test order(ks3) == 3
             @test getindex(ks3,2,3) == kronsum3[2,3]
         end
-        
+
         @test order(KS) == 2
         @test getmatrices(KS) == (A,B)
         @test getindex(KS,2,3) == kronsum[2,3]
-        
         
         ID = oneunit(D)
 

--- a/test/testkroneckersum.jl
+++ b/test/testkroneckersum.jl
@@ -1,77 +1,87 @@
 @testset "Kronecker sums" begin
 
+    As = (rand(4,4), sprand(4,4,1.0))
+    Bs = (rand(3,3), sprand(3,3,1.0))
+    Cs = (rand(5,5), sprand(5,5,1.0))
+    Ds = (rand(ComplexF64,6,6), sprand(ComplexF64,6,6,1.0))
+    arraytypes = (Matrix, SparseMatrixCSC)
+    for (A, B, C, D, arraytype) in zip(As, Bs, Cs, Ds, arraytypes)
+        IA = oneunit(A)
+        IB = oneunit(B)
 
-    A = rand(4,4); IA = oneunit(A)
-    B = rand(3,3); IB = oneunit(B)
+        KS = A ⊕ B
+        kronsum = kron(A, IB) + kron(IA, B)
 
-    KS = A ⊕ B
-    kronsum = kron(A, IB) + kron(IA, B)
+        @test eltype(KS) <: Float64
+        @test KS isa AbstractMatrix{Float64}
+        @test KS isa GeneralizedKroneckerProduct{Float64}
+        @test !isa(KS, AbstractKroneckerProduct)
 
-    @test eltype(KS) <: Float64
-    @test KS isa AbstractMatrix{Float64}
-    @test KS isa GeneralizedKroneckerProduct{Float64}
-    @test !isa(KS, AbstractKroneckerProduct)
+        @test collect(KS) ≈ kronsum
+        @test collect(KS) isa arraytype
 
-    @test collect(KS) ≈ kronsum
-    @test collect(KS) isa SparseMatrixCSC
+        @test issquare(KS)
 
-    @test issquare(KS)
+        IC = oneunit(C)
+        KS3 = A ⊕ B ⊕ C
+        KS3AB = (A ⊕ B) ⊕ C 
+        KS3BC = A ⊕ (B ⊕ C)
+        
+        kronsum3 = kron(A,IB,IC) + kron(IA,B,IC) + kron(IA,IB,C)
 
-    C = rand(5,5); IC = oneunit(C)
-    KS3 = A ⊕ B ⊕ C
-    kronsum3 = kron(A,IB,IC) + kron(IA,B,IC) + kron(IA,IB,C)
+        for ks3 in [KS3, KS3AB, KS3BC]
+            @test collect(ks3) ≈ kronsum3
+            @test collect(ks3) isa arraytype
+            @test order(ks3) == 3
+            @test getindex(ks3,2,3) == kronsum3[2,3]
+        end
+        
+        @test order(KS) == 2
+        @test getmatrices(KS) == (A,B)
+        @test getindex(KS,2,3) == kronsum[2,3]
+        
+        
+        ID = oneunit(D)
 
-    @test collect(KS3) ≈ kronsum3
-    @test collect(KS3) isa SparseMatrixCSC
-
-    @test order(KS) == 2
-    @test order(KS3) == 3
-
-    @test getmatrices(KS) == (A,B)
-
-    @test getindex(KS,2,3) == kronsum[2,3]
-    @test getindex(KS3,2,3) == kronsum3[2,3]
-
-    D = rand(ComplexF64,6,6); ID = oneunit(D)
-
-    @testset "Structure of sums" begin
-        @test size(A ⊕ D) == size(A) .* size(D,1)
-        @test size(B ⊕ C ⊕ D) == size(B) .* size(C) .* size(D)
-        @test eltype(A ⊕ B) == Float64
-        @test eltype(C ⊕ D) == ComplexF64
-    end
-
-    @testset "Basic linear algebra for sums" begin
-        @test tr(KS) ≈ tr(kronsum)
-        @test KS' == kronsum'
-        @test transpose(KS) == transpose(kronsum)
-        @test conj(KS) == conj(kronsum)
-    end
-
-    A = rand(10,10); B = rand(10,10); V = Diagonal(rand(10))
-    @testset "Vec trick for sums" begin
-        @test (A ⊕ B) * vec(V) == vec(B*V + V*transpose(A))
-    end
-
-    A = rand(3, 3); IA = oneunit(A)
-    B = rand(4, 4); IB = oneunit(B)
-    @testset "exp for Kronecker sum" begin
-        EKS = exp(A ⊕ B)
-        @test EKS isa AbstractKroneckerProduct
-        @test EKS ≈ exp(kron(A, IB) + kron(IA, B))
-    end
-
-    @testset "sum over Kronecker sum" begin
-        @test sum(KS) ≈ sum(kronsum)
-        @test sum(KS3) ≈ sum(kronsum3)
-
-        for dims in 1:2
-            @test sum(KS, dims=dims) ≈ sum(kronsum, dims=dims)
-            @test sum(KS3, dims=dims) ≈ sum(kronsum3, dims=dims)
+        @testset "Structure of sums" begin
+            @test size(A ⊕ D) == size(A) .* size(D,1)
+            @test size(B ⊕ C ⊕ D) == size(B) .* size(C) .* size(D)
+            @test eltype(A ⊕ B) == Float64
+            @test eltype(C ⊕ D) == ComplexF64
         end
 
-        @test_throws ArgumentError sum(KS, dims=-1)
-        @test_throws ArgumentError sum(KS3, dims=3)
+        @testset "Basic linear algebra for sums" begin
+            @test tr(KS) ≈ tr(kronsum)
+            @test KS' == kronsum'
+            @test transpose(KS) == transpose(kronsum)
+            @test conj(KS) == conj(kronsum)
+        end
+
+        A = rand(10,10); B = rand(10,10); V = Diagonal(rand(10))
+        @testset "Vec trick for sums" begin
+            @test (A ⊕ B) * vec(V) == vec(B*V + V*transpose(A))
+        end
+
+        A = rand(3, 3); IA = oneunit(A)
+        B = rand(4, 4); IB = oneunit(B)
+        @testset "exp for Kronecker sum" begin
+            EKS = exp(A ⊕ B)
+            @test EKS isa AbstractKroneckerProduct
+            @test EKS ≈ exp(kron(A, IB) + kron(IA, B))
+        end
+
+        @testset "sum over Kronecker sum" begin
+            @test sum(KS) ≈ sum(kronsum)
+            @test sum(KS3) ≈ sum(kronsum3)
+
+            for dims in 1:2
+                @test sum(KS, dims=dims) ≈ sum(kronsum, dims=dims)
+                @test sum(KS3, dims=dims) ≈ sum(kronsum3, dims=dims)
+            end
+
+            @test_throws ArgumentError sum(KS, dims=-1)
+            @test_throws ArgumentError sum(KS3, dims=3)
+        end
     end
 
 end


### PR DESCRIPTION
This is a continuation of #27.

For smaller matrices (out-of-place: `N ≲ 8`, in-place: `N ≲ 32`), computing Kronecker sums explicitly with dense matrices and `Diagonal` identity matrices would be more performant, compared with sparse arrays (as was preferred in #27).

For larger matrices, it is faster to use sparse arrays.

Below are some benchmarks for a single term in a kronecker sum.


Dense
---
```julia

using BenchmarkTools
using LinearAlgebra
using SparseArrays

for N in 2 .^ [0,1,2,3,4,5,6,7]
    A = rand(N,N); B = Diagonal(oneunit(A)); C = kron(A,B);
    println("Out-of-place N=$N")
    @btime kron($A,$B)
    println("In-place N=$N")
    @btime kron!($C,$A,$B)
    println("")
end
```

Dense timings
<details>
<summary> Click to expand timings</summary>

```
Out-of-place N=1
  45.244 ns (1 allocation: 96 bytes)
In-place N=1
  15.453 ns (0 allocations: 0 bytes)

Out-of-place N=2
  60.918 ns (1 allocation: 208 bytes)
In-place N=2
  25.499 ns (0 allocations: 0 bytes)

Out-of-place N=4
  569.928 ns (1 allocation: 2.13 KiB)
In-place N=4
  87.182 ns (0 allocations: 0 bytes)

Out-of-place N=8
  4.079 μs (2 allocations: 32.08 KiB)
In-place N=8
  617.090 ns (0 allocations: 0 bytes)

Out-of-place N=16
  64.967 μs (2 allocations: 512.08 KiB)
In-place N=16
  13.821 μs (0 allocations: 0 bytes)

Out-of-place N=32
  1.149 ms (2 allocations: 8.00 MiB)
In-place N=32
  162.917 μs (0 allocations: 0 bytes)

Out-of-place N=64
  53.302 ms (2 allocations: 128.00 MiB)
In-place N=64
  2.081 ms (0 allocations: 0 bytes)

Out-of-place N=128
  754.902 ms (2 allocations: 2.00 GiB)
In-place N=128
  20.843 ms (0 allocations: 0 bytes)
```
</details>


Sparse
---
```julia
p = 1.0
for N in 2 .^ [0,1,2,3,4,5,6,7]
    A = sprand(N,N,p); B = oneunit(A); C = kron(A,B);
    println("Out-of-place N=$N")
    @btime kron($A,$B)
    println("In-place N=$N")
    @btime kron!($C,$A,$B)
    println("")
end
```



<details>
<summary> Click to expand timings</summary>

```
Out-of-place N=1
  132.470 ns (3 allocations: 288 bytes)
In-place N=1
  27.849 ns (0 allocations: 0 bytes)

Out-of-place N=2
  200.434 ns (3 allocations: 416 bytes)
In-place N=2
  83.813 ns (0 allocations: 0 bytes)

Out-of-place N=4
  659.133 ns (3 allocations: 1.44 KiB)
In-place N=4
  435.384 ns (0 allocations: 0 bytes)

Out-of-place N=8
  4.371 μs (3 allocations: 8.86 KiB)
In-place N=8
  2.997 μs (0 allocations: 0 bytes)

Out-of-place N=16
  29.972 μs (5 allocations: 66.34 KiB)
In-place N=16
  22.710 μs (0 allocations: 0 bytes)

Out-of-place N=32
  226.747 μs (5 allocations: 520.34 KiB)
In-place N=32
  182.200 μs (0 allocations: 0 bytes)

Out-of-place N=64
  1.797 ms (6 allocations: 4.03 MiB)
In-place N=64
  1.420 ms (0 allocations: 0 bytes)

Out-of-place N=128
  14.451 ms (6 allocations: 32.13 MiB)
In-place N=128
  11.239 ms (0 allocations: 0 bytes)
```
</details>