### PR TITLE
Update docs and Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,18 +7,18 @@ version = "0.4.1"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NamedDims = "356022a1-0364-5f58-8944-0da4b18d706f"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-FillArrays = "^0"
+FillArrays = "0.9"
 NamedDims = "0.2"
-StatsBase = "~0.32"
+StatsBase = "0.32, 0.33"
 julia = "1"
 
 [extras]
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Random", "Test"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,7 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Kronecker = "2c470bb0-bcc8-11e8-3dad-c9649493f05e"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
-Documenter = "~0.23"
+Documenter = "0.25"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,11 +12,22 @@ Pkg.add.(tmp_packages) # IMPORTANT
 
 using Documenter, Kronecker, LinearAlgebra
 
-makedocs(sitename="Kronecker.jl",
-        authors = "Michiel Stock",
-        format = :html,
-        modules = [Kronecker])
+makedocs(
+    sitename = "Kronecker.jl",
+    authors = "Michiel Stock",
+    format = Documenter.HTML(),
+    modules = [Kronecker],
+    pages = Any[
+        "Basic use" => "man/basic.md",
+        "Types" => "man/types.md",
+        "Multiplication" => "man/multiplication.md",
+        "Factorization methods" => "man/factorization.md",
+        "Indexed Kronecker products" => "man/indexed.md",
+        "Kronecker sums" => "man/kroneckersums.md",
+        "Kronecker powers and graphs" => "man/kroneckerpowers.md"
+    ]
+)
 
 deploydocs(
-        repo = "github.com/MichielStock/Kronecker.jl.git",
-        )
+    repo = "github.com/MichielStock/Kronecker.jl.git",
+)


### PR DESCRIPTION
This does a few "meta" updates. The way the main `Project.toml` was written seemed to block updates or something. I removed obsolete dependencies and moved them, if necessary, to the Project.toml for the docs. I'd recommend to add the github action "CompatHelper". I found that very useful. Lastly, the pages were included sorted by the initial letter, not as "acclaimed" in the table of contents (maybe this was the way to do it with Documenter.jl v0.23). Some docstrings are missing or exist but are not included in the docs. Running the make file will list all of these issues.