### PR TITLE
Mixed eltypes mult

### DIFF
--- a/src/multiply.jl
+++ b/src/multiply.jl
@@ -71,7 +71,7 @@ for N in (1, 2)
         end
 
         rect_kernel! = Symbol("_kron_", op, "_kernel_rect!")
-        @eval function $rect_kernel!(temp::AbstractArray{T, $N}, q::AbstractArray{T, $N}, r_h::Int, c_h::Int, i_left::Int, m::MatrixOrFactorization{T}, i_right::Int) where T
+        @eval function $rect_kernel!(temp::AbstractArray{T1, $N}, q::AbstractArray{T2, $N}, r_h::Int, c_h::Int, i_left::Int, m::MatrixOrFactorization{T3}, i_right::Int) where {T1,T2,T3}
             # apply kron(I(i_left), m, I(i_right)) to the given vector q
 
             # don't bother checking for identity, since we know the matrix
@@ -105,7 +105,7 @@ for N in (1, 2)
         rect_func! = Symbol("_kron_", op, "_fast_rect!")
         ri = (op == :mul) ? 1 : 2
         ci = (op == :mul) ? 2 : 1
-        @eval function $rect_func!(out::AbstractArray{T, $N}, x::AbstractArray{T, $N}, matrices::NTuple{M, MatrixOrFactorization{T}}) where {T, M}
+        @eval function $rect_func!(out::AbstractArray{T1, $N}, x::AbstractArray{T2, $N}, matrices) where {T1,T2,M}
             r::Vector{Int} = [size(m, $ri) for m in matrices]
             c::Vector{Int} = [size(m, $ci) for m in matrices]
             i_left::Int = 1
@@ -130,12 +130,12 @@ for N in (1, 2)
         end
     end
 
-    @eval function _kronsum_mul_fast!(out::AbstractArray{T, $N}, x::AbstractArray{T, $N}, matrices::NTuple{M, AbstractMatrix{T}}) where {T, M}
+    @eval function _kronsum_mul_fast!(out::AbstractArray{T1, $N}, x::AbstractArray{T2, $N}, matrices) where {T1,T2,M}
         ns::Vector{Int} = [size(m, 1) for m in matrices]
         i_left::Int = 1
         i_right::Int = prod(ns)
 
-        out = fill!(out, zero(T))
+        out = fill!(out, zero(T1))
         temp = copy(x)
         # should use similar instead, but there seems to be a bug when using copy! with empty SparseArrays
         small_temp = _alloc_temp_array(maximum(ns), x)

--- a/src/multiply.jl
+++ b/src/multiply.jl
@@ -37,7 +37,7 @@ for N in (1, 2)
         end
 
         square_func! = Symbol("_kron_", op, "_fast_square!")
-        @eval function $square_func!(out::AbstractArray{T1, $N}, x::AbstractArray{T2, $N}, matrices::NTuple{M, MatrixOrFactorization{T3}}) where {T1,T2,T3,M}
+        @eval function $square_func!(out::AbstractArray{T1, $N}, x::AbstractArray{T2, $N}, matrices) where {T1,T2,M}
             ns::Vector{Int} = [size(m, 1) for m in matrices]
             i_left::Int = 1
             i_right::Int = prod(ns)

--- a/src/multiply.jl
+++ b/src/multiply.jl
@@ -14,10 +14,10 @@ for N in (1, 2)
             op_expr_square = :(@views q[slc, :] = $op!(temp[1:n, :], m, q[slc, :]))
         end
 
-        @eval function $square_kernel!(temp::AbstractArray{T, $N}, q::AbstractArray{T, $N}, n::Int, i_left::Int, m::MatrixOrFactorization{T}, i_right::Int) where T
+        @eval function $square_kernel!(temp::AbstractArray{T1, $N}, q::AbstractArray{T2, $N}, n::Int, i_left::Int, m::MatrixOrFactorization{T3}, i_right::Int) where {T1,T2,T3}
             # apply kron(I(l), m, I(r)) where m is square to the given vector x, overwriting x in the process
 
-            if m isa Factorization || m isa Adjoint{T, <:Factorization} || m isa Transpose{T, <:Factorization} || m != I
+            if m isa Factorization || m isa Adjoint{T3, <:Factorization} || m isa Transpose{T3, <:Factorization} || m != I
                 # if matrix is the identity, skip matmul/div, unless it's some sort factorization, then proceed anyway
                 irc = i_right * n
 
@@ -37,7 +37,7 @@ for N in (1, 2)
         end
 
         square_func! = Symbol("_kron_", op, "_fast_square!")
-        @eval function $square_func!(out::AbstractArray{T, $N}, x::AbstractArray{T, $N}, matrices::NTuple{M, MatrixOrFactorization{T}}) where {T, M}
+        @eval function $square_func!(out::AbstractArray{T1, $N}, x::AbstractArray{T2, $N}, matrices::NTuple{M, MatrixOrFactorization{T3}}) where {T1,T2,T3,M}
             ns::Vector{Int} = [size(m, 1) for m in matrices]
             i_left::Int = 1
             i_right::Int = prod(ns)

--- a/test/sums.jl
+++ b/test/sums.jl
@@ -1,0 +1,59 @@
+@testset "sums" begin
+
+    A = rand(10, 10)
+    B = rand(Bool, 5, 5)
+    C = randn(10, 10)
+    D = rand(1:10, 5, 5)
+
+    KA = A ⊗ B
+    KB = C ⊗ D
+
+    K = KA + KB
+    Kdense = kron(A, B) .+ kron(C, D)
+
+    v = randn(50)
+    V = randn(50, 3)
+
+    @test K ≈ Kdense
+    @test size(K) == size(Kdense)
+    @test collect(K) ≈ Kdense
+    @test sum(K) ≈ sum(Kdense)
+    @test sum(K, dims=1) ≈ sum(Kdense, dims=1)
+    @test K' ≈ Kdense'
+    @test transpose(K) ≈ transpose(Kdense)
+    @test conj(K) ≈ conj(Kdense)
+
+    @test K * v ≈ Kdense * v
+    @test K * V ≈ Kdense * V
+
+    @test 5 * K ≈ 5 * Kdense
+    @test K * 2.1 ≈ Kdense * 2.1
+
+    # recursive, kronecker products of Kronecker sums
+
+
+    
+    Kl = (KA + KB) ⊗ C
+    Kr = C ⊗ (KA + KB)
+    Kb = ((B ⊗ C) + (B ⊗ C)) ⊗ ((B ⊗ C) + (B ⊗ C))
+    
+    #=
+    Kl = kronecker(KA + KB, C)
+    Kr = kronecker(C, KA + KB) 
+    Kb = kronecker(kronecker(B, C) + kronecker(B, C), kronecker(B, C) + kronecker(B, C)) 
+    =#
+
+    n = size(Kl, 2)
+    m = size(Kb, 2)
+
+    v = randn(n)
+    u = randn(m)
+
+    
+    @test Kl * v ≈ collect(Kl) * v
+    @test Kr * v ≈ collect(Kr) * v
+    @test Kb * u ≈ collect(Kb) * u
+    
+
+
+end

--- a/test/testmultiply.jl
+++ b/test/testmultiply.jl
@@ -254,4 +254,24 @@ K3 = A ⊗ B ⊗ C
         compare_against_kron(K, k, x, X, y, Y)
     end
 
+    @testset "mixed products" begin
+        # square matrices
+        A = rand(5, 5)
+        B = rand(Bool, 5, 5)
+        C = rand(-10:10, 5, 5)
+        v = randn(5^3)
+
+        @test (A ⊗ B ⊗ C) * v ≈ collect(A ⊗ B ⊗ C) * v
+        @test (A ⊗ B ⊗ A) * v ≈ collect(A ⊗ B ⊗ A) * v
+        @test (B ⊗ B ⊗ C) * v ≈ collect(B ⊗ B ⊗ C) * v
+
+        # rectangular
+
+        A = rand(5, 5)
+        B = rand(Bool, 4, 5)
+        C = rand(-10:10, 5, 3)
+        v = randn(5*5*3)
+        @test (A ⊗ B ⊗ C) * v ≈ collect(A ⊗ B ⊗ C) * v
+        @test (C ⊗ B ⊗ A) * v ≈ collect(C ⊗ B ⊗ A) * v
+    end
 end

--- a/test/testmultiply.jl
+++ b/test/testmultiply.jl
@@ -1,5 +1,5 @@
 A = rand(3, 3)
-B = ones(4, 4)
+B = ones(Int, 4, 4)
 C = randn(5, 6)
 K = A ⊗ B
 X = collect(K)


### PR DESCRIPTION
Remove a type-dependency in the code for fast multiply by @emerali, fixing #70. This allows mixed type-matrices to be multiplied, like

```julia
A = rand(10, 10)
B = rand(Bool, 5, 5)
C = rand(-10:10, 5, 5)
K = A ⊗ B ⊗ C
v = randn(250)
K * v
```
There seem to be no drawbacks to this, but can you take a quick look, @emerali?
