### PR TITLE
Type-stable KroneckerPower

### DIFF
--- a/src/kroneckerpowers.jl
+++ b/src/kroneckerpowers.jl
@@ -13,12 +13,12 @@ Efficient way of storing Kronecker powers, e.g.
 
 K = A ⊗ A ⊗ ... ⊗ A.
 """
-struct KroneckerPower{T<:Any,TA<:AbstractMatrix{T}, N} <: AbstractKroneckerProduct{T}
+struct KroneckerPower{T<:Any,TA<:AbstractMatrix{T}} <: AbstractKroneckerProduct{T}
    A::TA
-   pow::Integer
-   function KroneckerPower(A::AbstractMatrix{T}, pow::Integer) where {T}
+   pow::Int
+   function KroneckerPower(A::AbstractMatrix, pow::Integer)
       @assert pow ≥ 2 "KroneckerPower only makes sense for powers greater than 1"
-      return new{eltype(A), typeof(A), pow}(A, pow)
+      return new{eltype(A), typeof(A)}(A, Int(pow))
     end
 end
 
@@ -38,15 +38,13 @@ type.
 """
 ⊗(A::AbstractMatrix, pow::Integer) = kronecker(A, pow)
 
-getallfactors(K::KroneckerPower{T,TA,N}) where {T,TA,N} = ntuple(_ -> K.A, K.pow)
+getallfactors(K::KroneckerPower) = ntuple(_ -> K.A, K.pow)
 
-getmatrices(K::KroneckerPower{T,TA,N}) where {T,TA,N} = (K.A, KroneckerPower(K.A, K.pow-1))
-getmatrices(K::KroneckerPower{T,TA,2}) where {T,TA} = (K.A, K.A)
-getmatrices(K::KroneckerPower{T,TA,1}) where {T,TA} = (K.A, )
+getmatrices(K::KroneckerPower) = (K.A, K.pow == 2 ? K.A : KroneckerPower(K.A, K.pow-1))
 
 order(K::KroneckerPower) = K.pow
 Base.size(K::KroneckerPower) = size(K.A).^K.pow
-Base.eltype(K::KroneckerPower{T,TA,N}) where {T,TA,N} = T
+Base.eltype(K::KroneckerPower{T}) where {T} = T
 issquare(K::KroneckerPower) = issquare(K.A)
 
 # SCALAR EQUIVALENTS FOR AbstractKroneckerProduct
@@ -135,12 +133,12 @@ function Base.conj(K::KroneckerPower)
 end
 
 # mixed-product property
-function Base.:*(K1::KroneckerPower{T,TA,N},
-                        K2::KroneckerPower{S,TB,N}) where {T,TA,S,TB,N}
+function Base.:*(K1::KroneckerPower, K2::KroneckerPower)
+    K1.pow == K2.pow || throw(ArgumentError("multiplication is only defined if all terms have the same exponent"))
     if size(K1, 2) != size(K2, 1)
         throw(DimensionMismatch("Mismatch between K1 and K2"))
     end
-    return KroneckerPower(K1.A * K2.A, N)
+    return KroneckerPower(K1.A * K2.A, K1.pow)
 end
 
 

--- a/src/kroneckerpowers.jl
+++ b/src/kroneckerpowers.jl
@@ -13,7 +13,7 @@ Efficient way of storing Kronecker powers, e.g.
 
 K = A ⊗ A ⊗ ... ⊗ A.
 """
-struct KroneckerPower{T<:Any,TA<:AbstractMatrix{T}} <: AbstractKroneckerProduct{T}
+struct KroneckerPower{T,TA<:AbstractMatrix{T}} <: AbstractKroneckerProduct{T}
    A::TA
    pow::Int
    function KroneckerPower(A::AbstractMatrix, pow::Integer)
@@ -44,7 +44,6 @@ getmatrices(K::KroneckerPower) = (K.A, K.pow == 2 ? K.A : KroneckerPower(K.A, K.
 
 order(K::KroneckerPower) = K.pow
 Base.size(K::KroneckerPower) = size(K.A).^K.pow
-Base.eltype(K::KroneckerPower{T}) where {T} = T
 issquare(K::KroneckerPower) = issquare(K.A)
 
 # SCALAR EQUIVALENTS FOR AbstractKroneckerProduct


### PR DESCRIPTION
This PR removes the exponent from the type-domain of a `KroneckerPower`, relying on runtime checks instead. This improves performance significantly, even though `getmatrices` loses type-stability. Fixes #101.

On master
```julia
julia> A = collect(reshape(1:16, 4, 4));

julia> K1 = kronecker(A, 3);

julia> @btime $K1[1,1]
  1.730 μs (10 allocations: 320 bytes)
1
```

This PR
```julia
julia> @btime $K1[1,1]
  97.187 ns (1 allocation: 32 bytes)
1
```