### PR TITLE
Optimized diag for square matrices and diagonal matrix multiplication

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -312,6 +312,14 @@ function Base.conj(K::AbstractKroneckerProduct)
     return kronecker(conj(A), conj(B))
 end
 
+function LinearAlgebra.diag(K::KroneckerProduct)
+    A, B = getmatrices(K)
+    if issquare(A) && issquare(B)
+        return kron(diag(K.A), diag(K.B))
+    end
+    return K[diagind(K)]
+end
+
 # COLLECTING
 
 #=

--- a/src/vectrick.jl
+++ b/src/vectrick.jl
@@ -209,6 +209,11 @@ function Base.:*(D::Diagonal, K::GeneralizedKroneckerProduct)
     return mul!(Matrix{promote_type(eltype(K), eltype(D))}(undef, size(K)...), D, K)
 end
 
+# special multiplication methods for Kronecker products
+Base.:*(K::KroneckerProduct{<:Any, <:Diagonal, <:Diagonal}, v::AbstractVector) = Diagonal(K) * v
+Base.:*(K::KroneckerProduct{<:Any, <:Diagonal, <:Diagonal}, D::Diagonal) = Diagonal(K) * D
+Base.:*(D::Diagonal, K::KroneckerProduct{<:Any, <:Diagonal, <:Diagonal}) = D * Diagonal(K)
+
 function Base.:*(v::Adjoint{<:Number, <:AbstractVector}, K::GeneralizedKroneckerProduct)
     out = Vector{promote_type(eltype(v), eltype(K))}(undef, last(size(K)))
     return mul!(out, K', v.parent)'

--- a/test/testbase.jl
+++ b/test/testbase.jl
@@ -64,6 +64,7 @@
         @test collect!(similar(M), K) ≈ M
         @test tr(K) ≈ tr(M)
         @test det(K) ≈ 0
+        @test diag(K) ≈ diag(M)
         @test logdet(K) ≈ -Inf
         @test !isposdef(K)
         @test !issymmetric(K)
@@ -91,6 +92,7 @@
         @test conj(K) ≈ conj(X)
         @test K' ≈ X'
         @test inv(K) ≈ inv(X)
+        @test diag(K) ≈ diag(X)
 
         # test on pos def functions
         As = A' * A

--- a/test/testmultiply.jl
+++ b/test/testmultiply.jl
@@ -274,4 +274,19 @@ K3 = A ⊗ B ⊗ C
         @test (A ⊗ B ⊗ C) * v ≈ collect(A ⊗ B ⊗ C) * v
         @test (C ⊗ B ⊗ A) * v ≈ collect(C ⊗ B ⊗ A) * v
     end
+
+    @testset "diagonal kronecker product" begin
+        D1 = Diagonal(ones(3));
+        D2 = Diagonal(ones(3).*2);
+        K = kronecker(D1, D1);
+        @testset "with diagonal" begin
+            D = kron(D2, D2);
+            @test K*D == collect(K) * collect(D)
+            @test D*K == collect(D) * collect(K)
+        end
+        @testset "with vector" begin
+            v = [i for i in axes(K, 2)];
+            @test K*v == collect(K)*v
+        end
+    end
 end


### PR DESCRIPTION
These methods avoids allocations while multiplying diagonal matrices:

On master:
```julia
julia> D1 = Diagonal(ones(300));

julia> K = kronecker(D1, D1);

julia> D = Diagonal(ones(size(K,2)));

julia> @btime $K * $D;
ERROR: OutOfMemoryError()
```

After this PR:
```julia
julia> @btime $K * $D;
  229.064 μs (12 allocations: 1.38 MiB)
```

There's also an optimized `diag` for square matrices, using the Kronecker product of the diagonals.