### PR TITLE
Specialize eigvals and svdvals

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -547,6 +547,18 @@ function LinearAlgebra.power_by_squaring(K::KroneckerProduct, p::Integer)
     kronecker(A^p, B^p)
 end
 
+function LinearAlgebra.svdvals(K::KroneckerProduct)
+    A, B = getmatrices(K)
+    σA = svdvals(A)
+    σB = svdvals(B)
+    σ = sort!(kron(σA, σB), rev = true)
+    n = minimum(size(K))
+    if length(σ) < n
+        append!(σ, zeros(eltype(σ), n - length(σ)))
+    end
+    return σ
+end
+
 # Broadcasting machinery
 
 Base.copyto!(dest::AbstractMatrix, K::AbstractKroneckerProduct) = collect!(dest, K)

--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -12,15 +12,15 @@ Otherwise, it collects the instance and runs eigen on the full matrix.
 The functions, `\\`, `inv`, and `logdet` are overloaded to efficiently work
 with this type.
 """
-function eigen(K::AbstractKroneckerProduct)
+function eigen(K::AbstractKroneckerProduct; kw...)
     checksquare(K)
     A, B = getmatrices(K)
     if issquare(A) && issquare(B)
-        A_λ, A_Γ = eigen(A)
-        B_λ, B_Γ = eigen(B)
+        A_λ, A_Γ = eigen(A; kw...)
+        B_λ, B_Γ = eigen(B; kw...)
         return Eigen(kron(A_λ, B_λ), kronecker(A_Γ, B_Γ))
     else
-        return eigen(Matrix(K))
+        return eigen(Matrix(K); kw...)
     end
 end
 
@@ -38,7 +38,7 @@ function LinearAlgebra.eigvals(K::AbstractKroneckerProduct; kw...)
         end
         return λ
     else
-        return eigvals(Matrix(K))
+        return eigvals(Matrix(K); kw...)
     end
 end
 

--- a/test/testbase.jl
+++ b/test/testbase.jl
@@ -107,6 +107,9 @@
         _m = reshape(1:4, 2,2)
         K2 = kronecker(_m, _m)
         @test (@inferred K2^2) == K2*K2 == collect(K2)^2
+
+        @test svdvals(K) ≈ svdvals(Kc) ≈ svdvals(X)
+        @test rank(K) == rank(Kc) == rank(X)
     end
 
     @testset "Mismatch errors" begin

--- a/test/testeigen.jl
+++ b/test/testeigen.jl
@@ -68,5 +68,11 @@ end
     K = kronecker(A, B);
     Kd = kron(A, B);
     @test eigvals(K) ≈ eigvals(Kd)
-    @test real(eigvals(K, sortby = real)) ≈ real(eigvals(Kd, sortby = real)) atol=1e-14 rtol=1e-8
+    if VERSION >= v"1.6"
+        @test real(eigvals(K, sortby = real)) ≈ real(eigvals(Kd, sortby = real)) atol=1e-14 rtol=1e-8
+    end
+    A = rand(2,3); B = rand(3, 2);
+    K = kronecker(A, B);
+    Kd = kron(A, B);
+    @test eigvals(K) ≈ eigvals(Kd)
 end

--- a/test/testeigen.jl
+++ b/test/testeigen.jl
@@ -62,3 +62,11 @@ end
     end
     test_non_square_extension()
 end
+
+@testset "eigvals" begin
+    A = rand(3,3); B = rand(4, 4);
+    K = kronecker(A, B);
+    Kd = kron(A, B);
+    @test eigvals(K) ≈ eigvals(Kd)
+    @test real(eigvals(K, sortby = real)) ≈ real(eigvals(Kd, sortby = real)) atol=1e-14 rtol=1e-8
+end

--- a/test/testeigen.jl
+++ b/test/testeigen.jl
@@ -67,12 +67,13 @@ end
     A = rand(3,3); B = rand(4, 4);
     K = kronecker(A, B);
     Kd = kron(A, B);
-    @test eigvals(K) ≈ eigvals(Kd)
+    sort_lexicographic(v) = sort!(v, by = x -> (real(x), imag(x)))
+    @test sort_lexicographic(eigvals(K)) ≈ sort_lexicographic(eigvals(Kd))
     if VERSION >= v"1.6"
         @test real(eigvals(K, sortby = real)) ≈ real(eigvals(Kd, sortby = real)) atol=1e-14 rtol=1e-8
     end
     A = rand(2,3); B = rand(3, 2);
     K = kronecker(A, B);
     Kd = kron(A, B);
-    @test eigvals(K) ≈ eigvals(Kd)
+    @test sort_lexicographic(eigvals(K)) ≈ sort_lexicographic(eigvals(Kd))
 end


### PR DESCRIPTION
While a specialized `eigen` implementation existed, an optimized `eigvals` was missing. This PR adds that for the kronecker product of square matrices. A specilized `svdvals` is also added that may avoid numerical accuracy issues.

After this PR
```julia
julia> A = rand(2,4); B = rand(3,2); K = kronecker(A, B);

julia> svdvals(collect(K))
6-element Vector{Float64}:
 1.5741245131184285
 0.5184682652428857
 0.20522677271825895
 0.06759539537430892
 4.3404532486333315e-17
 1.6516799651756504e-17

julia> svdvals(K)
6-element Vector{Float64}:
 1.5741245131184285
 0.5184682652428854
 0.20522677271825904
 0.0675953953743089
 0.0
 0.0

julia> A = rand(30,30); B = rand(20,20); K = kronecker(A, B);

julia> eigvals(K) ≈ eigvals(collect(K))
true

julia> svdvals(K) ≈ svdvals(collect(K))
true

julia> @btime eigvals($K);
  444.779 μs (33 allocations: 37.88 KiB)

julia> @btime eigvals($(collect(K)));
  252.574 ms (14 allocations: 2.93 MiB)

julia> @btime svdvals($K);
  137.499 μs (21 allocations: 32.23 KiB)

julia> @btime svdvals($(collect(K)));
  62.123 ms (9 allocations: 2.93 MiB)
```