### PR TITLE
Optimized addition, subtraction and negation

### DIFF
--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -51,12 +51,12 @@ end
 Collects eigenvalue decomposition of a `AbstractKroneckerProduct` type into a
 matrix.
 """
-function collect(E::Eigen{<:Number, <:Number, <:AbstractKroneckerProduct})
+function collect(E::Eigen{<:Number,<:Number,<:AbstractKroneckerProduct})
     λ, Γ = E
     return Γ * Diagonal(λ) * Γ'
 end
 
-function \(E::Eigen{<:Number, <:Number, <:AbstractKroneckerProduct}, v::AbstractVector{<:Number})
+function \(E::Eigen{<:Number,<:Number,<:AbstractKroneckerProduct}, v::AbstractVector{<:Number})
     λ, Γ = E
     return Γ * (Diagonal(λ) \ (Γ' * v))
 end
@@ -67,7 +67,7 @@ end
 Compute the logarithm of the determinant of the eigenvalue decomp of a Kronecker
 product.
 """
-logdet(E::Eigen{<:Number, <:Number, <:AbstractKroneckerProduct}) = sum(log, E.values)
+logdet(E::Eigen{<:Number,<:Number,<:AbstractKroneckerProduct}) = sum(log, E.values)
 
 """
     inv(K::Eigen)
@@ -75,4 +75,4 @@ logdet(E::Eigen{<:Number, <:Number, <:AbstractKroneckerProduct}) = sum(log, E.va
 Compute the inverse of the eigenvalue decomp of a Kronecker product. Returns
 another type of `Eigen`.
 """
-inv(E::Eigen{<:Number, <:Number, <:AbstractKroneckerProduct}) = Eigen(inv.(E.values), E.vectors)
+inv(E::Eigen{<:Number,<:Number,<:AbstractKroneckerProduct}) = Eigen(inv.(E.values), E.vectors)

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -34,7 +34,8 @@ function Base.getproperty(C::CholeskyKronecker, d::Symbol)
 end
 
 function Base.show(io::IO, mime::MIME{Symbol("text/plain")}, C::CholeskyKronecker)
-    summary(io, C); println(io)
+    summary(io, C)
+    println(io)
     println(io, "U factor:")
     show(io, mime, getproperty(C, :U))
 end
@@ -50,6 +51,6 @@ and `logdet` are overloaded to efficiently work with this type.
 function cholesky(K::AbstractKroneckerProduct; check = true)
     checksquare(K)
     A, B = getmatrices(K)
-    return CholeskyKronecker(cholesky(A, check=check),
-                            cholesky(B, check=check))
+    return CholeskyKronecker(cholesky(A, check = check),
+        cholesky(B, check = check))
 end

--- a/src/indexedkroncker.jl
+++ b/src/indexedkroncker.jl
@@ -1,4 +1,4 @@
-Index = AbstractVector{I} where I <: Integer
+Index = AbstractVector{I} where {I<:Integer}
 
 struct IndexedKroneckerProduct{T<:Any,TK<:AbstractKroneckerProduct} <: GeneralizedKroneckerProduct{T}
     K::TK
@@ -7,7 +7,7 @@ struct IndexedKroneckerProduct{T<:Any,TK<:AbstractKroneckerProduct} <: Generaliz
     r
     t
     function IndexedKroneckerProduct(K::AbstractKroneckerProduct, p::Index, q::Index, r::Index,
-                            t::Index)
+        t::Index)
         if order(K) != 2
             throw(DimensionMismatch(
                 "Indexed Kronecker only implemented for second order Kronecker systems"
@@ -44,13 +44,10 @@ Base.size(K::IndexedKroneckerProduct) = (length(K.p), length(K.t))
 function Base.getindex(K::IndexedKroneckerProduct, i::Int, j::Int)
     A, B = getmatrices(K)
     p, q, r, t = getindices(K)
-    return B[p[i],r[j]] * A[q[i],t[j]]
+    return B[p[i], r[j]] * A[q[i], t[j]]
 end
 
 function Base.getindex(K::AbstractKroneckerProduct, p::Index, q::Index, r::Index, t::Index)
-    N, M = getmatrices(K)
-    a, b = size(M)
-    c, d = size(N)
     return IndexedKroneckerProduct(K, p, q, r, t)
 end
 
@@ -81,19 +78,19 @@ function genvectrick!(M, N, v, u, p, q, r, t)
     @assert maximum(p) ≤ a && maximum(q) ≤ c
     @assert maximum(r) ≤ b && maximum(t) ≤ d
     u .= 0  # reset for inplace
-    if a * e + d * f < c * e + b *f
+    if a * e + d * f < c * e + b * f
         # compute T = VM'
         T = zeros(eltype(v), d, a)
         @simd for h in 1:e
             i, j = r[h], t[h]
             @simd for k in 1:a
-                @inbounds T[j,k] += v[h] * M[k,i]
+                @inbounds T[j, k] += v[h] * M[k, i]
             end
         end
         @simd for h in 1:f
             i, j = p[h], q[h]
             @simd for k in 1:d
-                @inbounds u[h] += N[j,k] * T[k,i]
+                @inbounds u[h] += N[j, k] * T[k, i]
             end
         end
     else
@@ -102,13 +99,13 @@ function genvectrick!(M, N, v, u, p, q, r, t)
         @simd for h in 1:e
             i, j = r[h], t[h]
             @simd for k in 1:c
-                @inbounds S[k,j] += v[h] * N[k,j]
+                @inbounds S[k, j] += v[h] * N[k, j]
             end
         end
         @simd for h in 1:f
             i, j = p[h], q[h]
             @simd for k in 1:b
-                @inbounds u[h] += S[j,k] * M[i,k]
+                @inbounds u[h] += S[j, k] * M[i, k]
             end
         end
     end

--- a/src/kroneckergraphs.jl
+++ b/src/kroneckergraphs.jl
@@ -44,7 +44,7 @@ product (but is still light in memory use). Consider using `fastsample`.
 """
 function naivesample(P::AbstractKroneckerProduct)
     @assert isprob(P) throw(DomainError(
-                            "All values of K should be between 0 and 1"))
+        "All values of K should be between 0 and 1"))
     G = spzeros(Bool, size(P)...)
     for I in CartesianIndices(P)
         if P[I] > rand()  # QUESTION: is this the most efficient way?
@@ -61,8 +61,8 @@ Samples the indices from an `AbstractMatrix`. Probability of sampling indices is
 proportional to the size of the corresponding value. Does not do any checks on A.
 """
 sampleindices(A::AbstractMatrix, s::Int) = Tuple.(sample(CartesianIndices(A),
-                                                    Weights(vec(A), sum(A)), s,
-                                                    replace=true))
+    Weights(vec(A), sum(A)), s,
+    replace = true))
 
 """
 sampleindices(K::AbstractKroneckerProduct, s::Int)
@@ -92,11 +92,11 @@ Kronecker graph.
 """
 function fastsample(P::AbstractKroneckerProduct)
     @assert isprob(P) throw(DomainError(
-                            "All values of K should be between 0 and 1"))
+        "All values of K should be between 0 and 1"))
     G = spzeros(Bool, size(P)...)
     n = Int(round(sum(P)))  # expected number of edges
     for (i, j) in sampleindices(P, n)
-        @inbounds G[i,j] = true
+        @inbounds G[i, j] = true
     end
     return G
 end

--- a/src/kroneckerpowers.jl
+++ b/src/kroneckerpowers.jl
@@ -14,11 +14,11 @@ Efficient way of storing Kronecker powers, e.g.
 K = A ⊗ A ⊗ ... ⊗ A.
 """
 struct KroneckerPower{T,TA<:AbstractMatrix{T}} <: AbstractKroneckerProduct{T}
-   A::TA
-   pow::Int
-   function KroneckerPower(A::AbstractMatrix, pow::Integer)
-      @assert pow ≥ 2 "KroneckerPower only makes sense for powers greater than 1"
-      return new{eltype(A), typeof(A)}(A, Int(pow))
+    A::TA
+    pow::Int
+    function KroneckerPower(A::AbstractMatrix, pow::Integer)
+        @assert pow ≥ 2 "KroneckerPower only makes sense for powers greater than 1"
+        return new{eltype(A),typeof(A)}(A, Int(pow))
     end
 end
 
@@ -40,10 +40,11 @@ type.
 
 getallfactors(K::KroneckerPower) = ntuple(_ -> K.A, K.pow)
 
-getmatrices(K::KroneckerPower) = (K.pow == 2 ? K.A : KroneckerPower(K.A, K.pow-1), K.A)
+getmatrices(K::KroneckerPower) = (K.pow == 2 ? K.A : KroneckerPower(K.A, K.pow - 1), K.A)
+lastmatrix(K::KroneckerPower) = K.A
 
 order(K::KroneckerPower) = K.pow
-Base.size(K::KroneckerPower) = size(K.A).^K.pow
+Base.size(K::KroneckerPower) = size(K.A) .^ K.pow
 issquare(K::KroneckerPower) = issquare(K.A)
 
 # SCALAR EQUIVALENTS FOR AbstractKroneckerProduct
@@ -150,7 +151,7 @@ function Base.:*(K1::KroneckerPower, K2::KroneckerPower)
     K1.pow == K2.pow || throw(ArgumentError("multiplication is only defined if all terms have the same exponent"))
     _mulmixed(K1, K2)
 end
-const KronPowDiagonal = KroneckerPower{<:Any, <:Diagonal}
+const KronPowDiagonal = KroneckerPower{<:Any,<:Diagonal}
 function Base.:*(K1::KronPowDiagonal, K2::KronPowDiagonal)
     K1.pow == K2.pow || throw(ArgumentError("multiplication is only defined if all terms have the same exponent"))
     _mulmixed(K1, K2)

--- a/src/kroneckersum.jl
+++ b/src/kroneckersum.jl
@@ -1,13 +1,13 @@
 abstract type AbstractKroneckerSum{T} <: GeneralizedKroneckerProduct{T} end
 
-struct KroneckerSum{T<:Any, TA<:AbstractMatrix, TB<:AbstractMatrix} <: AbstractKroneckerSum{T}
+struct KroneckerSum{T<:Any,TA<:AbstractMatrix,TB<:AbstractMatrix} <: AbstractKroneckerSum{T}
     A::TA
     B::TB
     function KroneckerSum(A::AbstractMatrix{T},
-                            B::AbstractMatrix{V}) where {T, V}
+        B::AbstractMatrix{V}) where {T,V}
         (issquare(A) && issquare(B)) || throw(DimensionMismatch(
-                                "KroneckerSum only applies to square matrices"))
-        return new{promote_type(T, V), typeof(A), typeof(B)}(A, B)
+            "KroneckerSum only applies to square matrices"))
+        return new{promote_type(T, V),typeof(A),typeof(B)}(A, B)
     end
 end
 
@@ -21,7 +21,7 @@ Construct a sum of Kronecker products between two square matrices and their
 respective identity matrices. Does not evaluate the Kronecker products
 explicitly.
 """
-kroneckersum(A::AbstractMatrix, B::AbstractMatrix) = KroneckerSum(A,B)
+kroneckersum(A::AbstractMatrix, B::AbstractMatrix) = KroneckerSum(A, B)
 
 """
     kroneckersum(A::AbstractMatrix, B::AbstractMatrix...)
@@ -31,7 +31,7 @@ Higher-order lazy kronecker sum, e.g.
 kroneckersum(A,B,C,D)
 ```
 """
-kroneckersum(A::AbstractMatrix, B::AbstractMatrix...) = kroneckersum(A,kroneckersum(B...))
+kroneckersum(A::AbstractMatrix, B::AbstractMatrix...) = kroneckersum(A, kroneckersum(B...))
 
 """
     kroneckersum(A::AbstractMatrix, pow::Int)
@@ -44,7 +44,7 @@ function kroneckersum(A::AbstractMatrix, pow::Int)
     if pow == 1
         return A
     else
-        return A ⊕ kroneckersum(A, pow-1)
+        return A ⊕ kroneckersum(A, pow - 1)
     end
 end
 
@@ -86,16 +86,15 @@ Base.size(K::AbstractKroneckerSum, dim::Int) = size(K)[dim]
 
 function Base.getindex(K::AbstractKroneckerSum, i1::Int, i2::Int)
     A, B = getmatrices(K)
-    m, n = size(A)
     k, l = size(B)
     i₁, j₁ = cld(i1, k), cld(i2, l)
     i₂, j₂ = (i1 - 1) % k + 1, (i2 - 1) % l + 1
     v = zero(eltype(K))
     if i₁ == j₁
-        v += B[i₂,j₂]
+        v += B[i₂, j₂]
     end
     if i₂ == j₂
-        v += A[i₁,j₁]
+        v += A[i₁, j₁]
     end
     return v
 end
@@ -144,11 +143,11 @@ end
 Creates a lazy instance of a `KroneckerSum` type with sparse
 matrices. If the matrices are already sparse, `K` is returned.
 """
-function SparseArrays.sparse(K::KroneckerSum{T, TA, TB}) where {T, TA <: AbstractSparseMatrix, TB <: AbstractSparseMatrix}
+function SparseArrays.sparse(K::KroneckerSum{T,TA,TB}) where {T,TA<:AbstractSparseMatrix,TB<:AbstractSparseMatrix}
     return K
 end
 
-function SparseArrays.sparse(K::KroneckerSum{T, TA, TB}) where {T, TA <: AbstractMatrix, TB <: AbstractMatrix}
+function SparseArrays.sparse(K::KroneckerSum{T,TA,TB}) where {T,TA<:AbstractMatrix,TB<:AbstractMatrix}
     return sparse(K.A) ⊕ sparse(K.B)
 end
 
@@ -169,7 +168,7 @@ function Base.kron(A::AbstractMatrix, K::AbstractKroneckerSum)
     return kron(A, collect(K))
 end
 
-function Base.kron(K1::AbstractKroneckerSum, K2:: AbstractKroneckerSum)
+function Base.kron(K1::AbstractKroneckerSum, K2::AbstractKroneckerSum)
     return kron(collect(K1), collect(K2))
 end
 
@@ -180,7 +179,7 @@ end
 
 function Base.transpose(K::AbstractKroneckerSum)
     A, B = getmatrices(K)
-    return kroneckersum(transpose(A),transpose(B))
+    return kroneckersum(transpose(A), transpose(B))
 end
 
 function Base.conj(K::AbstractKroneckerSum)
@@ -199,13 +198,13 @@ function Base.exp(K::AbstractKroneckerSum)
     return kronecker(exp(A), exp(B))
 end
 
-function Base.sum(K::KroneckerSum; dims::Union{Int,Nothing}=nothing)
+function Base.sum(K::KroneckerSum; dims::Union{Int,Nothing} = nothing)
     A, B = getmatrices(K)
     n, m = size(A, 1), size(B, 1)
-    if dims==1
-        return kron(sum(A, dims=1), ones(1, m)) .+ kron(ones(1, n), sum(B, dims=1))
-    elseif dims==2
-        return kron(sum(A, dims=2), ones(m, 1)) .+ kron(ones(n, 1), sum(B, dims=2))
+    if dims == 1
+        return kron(sum(A, dims = 1), ones(1, m)) .+ kron(ones(1, n), sum(B, dims = 1))
+    elseif dims == 2
+        return kron(sum(A, dims = 2), ones(m, 1)) .+ kron(ones(n, 1), sum(B, dims = 2))
     elseif dims isa Nothing
         m * sum(A) + n * sum(B)
     else

--- a/src/names.jl
+++ b/src/names.jl
@@ -20,4 +20,4 @@ _join(i::Symbol, j::Symbol) = _join(Val(i), Val(j))
 @generated _join(::Val{i}, ::Val{j}) where {i,j} = QuoteNode(Symbol(i, :ᵡ, j))
 
 kron_names(L::Tuple, ::Val{1}) = L
-kron_names(L::Tuple, ::Val{p}) where {p} = kron_names(kron_names(L,L), Val(p-1))
+kron_names(L::Tuple, ::Val{p}) where {p} = kron_names(kron_names(L, L), Val(p - 1))

--- a/test/testbase.jl
+++ b/test/testbase.jl
@@ -207,7 +207,22 @@
 
         @test K + zero(K) ≈ Kc + zero(Kc) ≈ X + zero(X)
 
-        @test K + L ≈ L + K ≈ collect(K) + collect(L)
+        @test K + L ≈ L + K ≈ Kc + collect(L)
+
+        @test -K ≈ collect(-K) ≈ -Kc
+        @test -K3 ≈ collect(-K3) ≈ -K3c
+
+        local Kd, Kd2, Ktd, K34, K43
+        Kd = rand(2, 2) ⊗ Diagonal(rand(2))
+        @test -Kd ≈ collect(-Kd) ≈ -collect(Kd)
+        Kd2 = Diagonal(rand(2)) ⊗ rand(2, 2)
+        @test -Kd2 ≈ collect(-Kd2) ≈ -collect(Kd2)
+        Ktd = rand(2, 2) ⊗ Tridiagonal(ones(3), zeros(4), ones(3))
+        @test -Ktd ≈ collect(-Ktd) ≈ -collect(Ktd)
+        K34 = rand(3, 3) ⊗ rand(4, 4)
+        K43 = rand(4, 4) ⊗ rand(3, 3)
+        @test K34 + K43 ≈ collect(K34) + collect(K43)
+        @test K34 - K43 ≈ collect(K34) - collect(K43)
 
         @testset "add/subtract digonal and kronecker product" begin
             local D1, K, Kc, D2

--- a/test/testkroneckersum.jl
+++ b/test/testkroneckersum.jl
@@ -1,10 +1,10 @@
 @testset "Kronecker sums" begin
     using SparseArrays
 
-    As = (rand(4,4), sprand(4,4,1.0))
-    Bs = (rand(3,3), sprand(3,3,1.0))
-    Cs = (rand(5,5), sprand(5,5,1.0))
-    Ds = (rand(ComplexF64,6,6), sprand(ComplexF64,6,6,1.0))
+    As = (rand(4, 4), sprand(4, 4, 1.0))
+    Bs = (rand(3, 3), sprand(3, 3, 1.0))
+    Cs = (rand(5, 5), sprand(5, 5, 1.0))
+    Ds = (rand(ComplexF64, 6, 6), sprand(ComplexF64, 6, 6, 1.0))
     arraytypes = (Matrix, SparseMatrixCSC)
 
     for (A, B, C, D, arraytype) in zip(As, Bs, Cs, Ds, arraytypes)
@@ -29,23 +29,23 @@
         KS3AB = (A ⊕ B) ⊕ C
         KS3BC = A ⊕ (B ⊕ C)
 
-        kronsum3 = kron(A,IB,IC) + kron(IA,B,IC) + kron(IA,IB,C)
+        kronsum3 = kron(A, IB, IC) + kron(IA, B, IC) + kron(IA, IB, C)
 
         for ks3 in [KS3, KS3AB, KS3BC]
             @test collect(ks3) ≈ kronsum3
             @test collect(ks3) isa AbstractSparseMatrix
             @test order(ks3) == 3
-            @test getindex(ks3,2,3) == kronsum3[2,3]
+            @test getindex(ks3, 2, 3) == kronsum3[2, 3]
         end
 
         @test order(KS) == 2
-        @test getmatrices(KS) == (A,B)
-        @test getindex(KS,2,3) == kronsum[2,3]
+        @test getmatrices(KS) == (A, B)
+        @test getindex(KS, 2, 3) == kronsum[2, 3]
 
         ID = oneunit(D)
 
         @testset "Structure of sums" begin
-            @test size(A ⊕ D) == size(A) .* size(D,1)
+            @test size(A ⊕ D) == size(A) .* size(D, 1)
             @test size(B ⊕ C ⊕ D) == size(B) .* size(C) .* size(D)
             @test eltype(A ⊕ B) == Float64
             @test eltype(C ⊕ D) == ComplexF64
@@ -58,13 +58,17 @@
             @test conj(KS) == conj(kronsum)
         end
 
-        A = rand(10,10); B = rand(10,10); V = Diagonal(rand(10))
+        A = rand(10, 10)
+        B = rand(10, 10)
+        V = Diagonal(rand(10))
         @testset "Vec trick for sums" begin
-            @test (A ⊕ B) * vec(V) == vec(B*V + V*transpose(A))
+            @test (A ⊕ B) * vec(V) == vec(B * V + V * transpose(A))
         end
 
-        A = rand(3, 3); IA = oneunit(A)
-        B = rand(4, 4); IB = oneunit(B)
+        A = rand(3, 3)
+        IA = oneunit(A)
+        B = rand(4, 4)
+        IB = oneunit(B)
         @testset "exp for Kronecker sum" begin
             EKS = exp(A ⊕ B)
             @test EKS isa AbstractKroneckerProduct
@@ -76,12 +80,12 @@
             @test sum(KS3) ≈ sum(kronsum3)
 
             for dims in 1:2
-                @test sum(KS, dims=dims) ≈ sum(kronsum, dims=dims)
-                @test sum(KS3, dims=dims) ≈ sum(kronsum3, dims=dims)
+                @test sum(KS, dims = dims) ≈ sum(kronsum, dims = dims)
+                @test sum(KS3, dims = dims) ≈ sum(kronsum3, dims = dims)
             end
 
-            @test_throws ArgumentError sum(KS, dims=-1)
-            @test_throws ArgumentError sum(KS3, dims=3)
+            @test_throws ArgumentError sum(KS, dims = -1)
+            @test_throws ArgumentError sum(KS3, dims = 3)
         end
 
         @testset "sparse Kronecker sum" begin
@@ -102,9 +106,9 @@
         @testset "call kron on Kronecker sums" begin
             for ks in (KS, KS3, KS3AB, KS3BC)
                 cks = collect(ks)
-                @test kron(ks,D) ≈ kron(cks, D)
-                @test kron(D,ks) ≈ kron(D,cks)
-                @test kron(ks,ks) ≈ kron(cks, cks)
+                @test kron(ks, D) ≈ kron(cks, D)
+                @test kron(D, ks) ≈ kron(D, cks)
+                @test kron(ks, ks) ≈ kron(cks, cks)
             end
         end
     end

--- a/test/testmultiply.jl
+++ b/test/testmultiply.jl
@@ -36,7 +36,7 @@ K3 = A ⊗ B ⊗ C
         D = randn(3, 2)
         C_pow = kronecker(C, 3)
         D_pow = kronecker(D, 3)
-        @test collect(C_pow * D_pow) ≈ collect(kronecker(C*D, 3))
+        @test collect(C_pow * D_pow) ≈ collect(kronecker(C * D, 3))
 
         @test_throws DimensionMismatch (D_pow * C_pow)
     end
@@ -64,7 +64,7 @@ K3 = A ⊗ B ⊗ C
         @test_throws DimensionMismatch K * V
         @test_throws DimensionMismatch K * reshape(V, 2, 6)
         K3 = A ⊗ B ⊗ C
-        v3 = sprand(size(K3, 2),1.0)
+        v3 = sprand(size(K3, 2), 1.0)
         @test K3 * vec(v3) ≈ collect(K3) * v3
         u = similar(v)
         @test mul!(u, K, v) ≈ X * v
@@ -84,9 +84,9 @@ K3 = A ⊗ B ⊗ C
         @test sum(K) ≈ sum(X)
         @test sum(K3) ≈ sum(collect(K3))
 
-        @test sum(K, dims=1) ≈ sum(X, dims=1)
-        @test sum(K3, dims=2) ≈ sum(collect(K3), dims=2)
-        @test sum(K3, dims=2) isa AbstractKroneckerProduct
+        @test sum(K, dims = 1) ≈ sum(X, dims = 1)
+        @test sum(K3, dims = 2) ≈ sum(collect(K3), dims = 2)
+        @test sum(K3, dims = 2) isa AbstractKroneckerProduct
 
         @test sum(kronecker(A, 3)) ≈ sum(kron(A, A, A))
     end
@@ -196,7 +196,7 @@ K3 = A ⊗ B ⊗ C
 
 
     @testset "10-factor square KroneckerProduct" begin
-        matrices = [randn(2,2) for i in 1:10]
+        matrices = [randn(2, 2) for i in 1:10]
         v = randn(2^10)
         V = randn(2^10, 5)
 
@@ -213,7 +213,7 @@ K3 = A ⊗ B ⊗ C
     @testset "10-factor square KroneckerPower" begin
         # reduce condition number of the matrix to avoid accidentally triggering a
         #  test failure
-        A = randn(2,2) + 20I
+        A = randn(2, 2) + 20I
         A /= opnorm(A)
 
         v = randn(2^10)
@@ -226,7 +226,7 @@ K3 = A ⊗ B ⊗ C
     end
 
     @testset "10-factor rectangular KroneckerProduct" begin
-        matrices = [randn(3,2) for i in 1:10]
+        matrices = [randn(3, 2) for i in 1:10]
         x = randn(2^10)
         X = randn(2^10, 5)
         y = randn(3^10)
@@ -239,8 +239,8 @@ K3 = A ⊗ B ⊗ C
     end
 
     @testset "10-factor mixed KroneckerProduct" begin
-        matrices1 = [randn(2,2) for i in 1:5]
-        matrices2 = [randn(3,2) for i in 1:5]
+        matrices1 = [randn(2, 2) for i in 1:5]
+        matrices2 = [randn(3, 2) for i in 1:5]
         x = randn(2^10)
         X = randn(2^10, 5)
         y = randn(2^5 * 3^5)
@@ -270,29 +270,29 @@ K3 = A ⊗ B ⊗ C
         A = rand(5, 5)
         B = rand(Bool, 4, 5)
         C = rand(-10:10, 5, 3)
-        v = randn(5*5*3)
+        v = randn(5 * 5 * 3)
         @test (A ⊗ B ⊗ C) * v ≈ collect(A ⊗ B ⊗ C) * v
         @test (C ⊗ B ⊗ A) * v ≈ collect(C ⊗ B ⊗ A) * v
     end
 
     @testset "diagonal kronecker product" begin
-        D1 = Diagonal(ones(Int, 3));
-        K = kronecker(D1, D1);
-        K3 = kronecker(D1, 3);
-        Kdense = kron(D1, D1);
-        K3dense = kron(D1, D1, D1);
+        D1 = Diagonal(ones(Int, 3))
+        K = kronecker(D1, D1)
+        K3 = kronecker(D1, 3)
+        Kdense = kron(D1, D1)
+        K3dense = kron(D1, D1, D1)
         @testset "with kronecker" begin
             @test K * K == Kdense * Kdense
             @test K3 * K3 == K3dense * K3dense
         end
         @testset "with diagonal" begin
-            D2 = Diagonal(ones(Int, 3).*2);
-            D = kron(D2, D2);
-            D3 = kron(D2, D2, D2);
+            D2 = Diagonal(ones(Int, 3) .* 2)
+            D = kron(D2, D2)
+            D3 = kron(D2, D2, D2)
             for (_K, _Kdense, _D) in Any[(K, Kdense, D), (K3, K3dense, D3)]
                 _Kcollect = collect(_K)
-                @test _K * _D == _Kdense*_D == _Kcollect * collect(_D)
-                @test _D * _K == _Kdense*_D == collect(_D) * _Kcollect
+                @test _K * _D == _Kdense * _D == _Kcollect * collect(_D)
+                @test _D * _K == _Kdense * _D == collect(_D) * _Kcollect
             end
         end
         @testset "with triangular" begin
@@ -307,8 +307,8 @@ K3 = A ⊗ B ⊗ C
             end
         end
         @testset "with vector" begin
-            v = [i for i in axes(K, 2)];
-            @test K*v == Kdense*v
+            v = [i for i in axes(K, 2)]
+            @test K * v == Kdense * v
         end
         @testset "with adjoint" begin
             vadj = [i for i in axes(K, 1)]'

--- a/test/testnames.jl
+++ b/test/testnames.jl
@@ -1,7 +1,7 @@
 using NamedDims
 @testset "named" begin
-    A = rand(Int8, 2,2)
-    B = rand(Int8, 3,3)
+    A = rand(Int8, 2, 2)
+    B = rand(Int8, 3, 3)
     ndA = NamedDimsArray(A, (:ia, :ja))
     ndB = NamedDimsArray(B, (:ib, :jb))
 


### PR DESCRIPTION
This PR reduces some temporary allocations in addition and subtraction, and optimizes unary negation for `KroneckerProduct`.

Master:
```julia
julia> A = rand(30,30) ⊗ rand(40, 40);

julia> B = rand(40,40) ⊗ rand(30,30);

julia> C = rand(40,40) ⊗ Diagonal(rand(30));

julia> @btime $A + $B;
  5.653 ms (6 allocations: 32.96 MiB)

julia> @btime $A - $B;
  5.836 ms (6 allocations: 32.96 MiB)

julia> @btime -$A;
  2.055 ms (2 allocations: 10.99 MiB)

julia> @btime -$C;
  3.896 ms (2 allocations: 10.99 MiB)
```

This PR:
```julia
julia> @btime $A + $B;
  4.846 ms (4 allocations: 21.97 MiB)

julia> @btime $A - $B;
  4.920 ms (4 allocations: 21.97 MiB)

julia> @btime -$A; # lazy kronecker product
  1.086 μs (1 allocation: 7.19 KiB)

julia> @btime -$C; # lazy kronecker product
  84.321 ns (1 allocation: 304 bytes)
```

Sorry about the whitespace changes, it's an automated VSCode setting that I've not figured out how to disable. The main changes are lines 411-494 in src/base.jl, and an added `lastmatrix` method in kroneckerpowers.jl on line 44