### PR TITLE
Resolve ambiguity in multiplying Diagonal kronecker products

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -41,11 +41,11 @@ end
 
 Concrete Kronecker product between two matrices `A` and `B`.
 """
-struct KroneckerProduct{T<:Any, TA<:AbstractMatrix, TB<:AbstractMatrix} <: AbstractKroneckerProduct{T}
+struct KroneckerProduct{T<:Any,TA<:AbstractMatrix,TB<:AbstractMatrix} <: AbstractKroneckerProduct{T}
     A::TA
     B::TB
-    function KroneckerProduct(A::AbstractMatrix{T}, B::AbstractMatrix{V}) where {T, V}
-        return new{promote_type(T, V), typeof(A), typeof(B)}(A, B)
+    function KroneckerProduct(A::AbstractMatrix{T}, B::AbstractMatrix{V}) where {T,V}
+        return new{promote_type(T, V),typeof(A),typeof(B)}(A, B)
     end
 end
 
@@ -65,9 +65,9 @@ Kronecker product explictly.
 kronecker(A::AbstractMatrix, B::AbstractMatrix) = KroneckerProduct(A, B)
 
 # version that have a vector as input reshape to matrices
-kronecker(A::AbstractVector, B::AbstractMatrix) = KroneckerProduct(reshape(A,:,1), B)
-kronecker(A::AbstractMatrix, B::AbstractVector) = KroneckerProduct(A, reshape(B,:,1))
-kronecker(A::AbstractVector, B::AbstractVector) = KroneckerProduct(reshape(A,:,1), reshape(B,:,1))
+kronecker(A::AbstractVector, B::AbstractMatrix) = KroneckerProduct(reshape(A, :, 1), B)
+kronecker(A::AbstractMatrix, B::AbstractVector) = KroneckerProduct(A, reshape(B, :, 1))
+kronecker(A::AbstractVector, B::AbstractVector) = KroneckerProduct(reshape(A, :, 1), reshape(B, :, 1))
 
 """
     kronecker(A::AbstractMatrix, B::AbstractMatrix)
@@ -78,7 +78,7 @@ kronecker(A, B, C, D)
 ```
 """
 kronecker(A::AbstractVecOrMat, B::AbstractVecOrMat...) = kronecker(A,
-                                                            kronecker(B...))
+    kronecker(B...))
 
 """
     ⊗(A::AbstractMatrix, B::AbstractMatrix)
@@ -98,7 +98,7 @@ Uses recursion if `K` is of an order greater than two.
 function getindex(K::AbstractKroneckerProduct, i1::Integer, i2::Integer)
     A, B = getmatrices(K)
     k, l = size(B)
-    return (A[cld(i1, k), cld(i2, l)]::eltype(A)) * (B[(i1 - 1) % k + 1, (i2 - 1) % l + 1]::eltype(B))
+    return (A[cld(i1, k), cld(i2, l)]::eltype(A)) * (B[(i1-1)%k+1, (i2-1)%l+1]::eltype(B))
 end
 
 
@@ -341,10 +341,10 @@ _maybecollect(A::AbstractArray) = A
 # function for in-place Kronecker product
 function _kron!(C::AbstractArray, A::AbstractArray, B::AbstractArray)
     m = first(LinearIndices(C)) - 1
-    @inbounds for j = axes(A,2), l = axes(B,2), i = axes(A,1)
-        Aij = A[i,j]
-        for k = axes(B,1)
-            C[m += 1] = Aij * B[k,l]
+    @inbounds for j = axes(A, 2), l = axes(B, 2), i = axes(A, 1)
+        Aij = A[i, j]
+        for k = axes(B, 1)
+            C[m+=1] = Aij * B[k, l]
         end
     end
     return C
@@ -354,16 +354,16 @@ _kron!(C::AbstractArray, A::GeneralizedKroneckerProduct, B::AbstractArray) = _kr
 _kron!(C::AbstractArray, A::AbstractArray, B::GeneralizedKroneckerProduct) = _kron!(C, A, collect(B))
 _kron!(C::AbstractArray, A::GeneralizedKroneckerProduct, B::GeneralizedKroneckerProduct) = _kron!(C, collect(A), collect(B))
 
-@inline function _kron!(C::AbstractArray, As::Tuple{AbstractArray, Vararg{AbstractArray}}, Bs::Tuple{AbstractArray, Vararg{AbstractArray}}, f = identity)
+@inline function _kron!(C::AbstractArray, As::Tuple{AbstractArray,Vararg{AbstractArray}}, Bs::Tuple{AbstractArray,Vararg{AbstractArray}}, f = identity)
     m = first(LinearIndices(C)) - 1
     A1 = first(As)
     B1 = first(Bs)
-    for j = axes(A1,2), l = axes(B1,2), i = axes(A1,1)
-        Aijs = map(A -> A[i,j], As)
-        for k = 1:size(Bs[1],1)
-            Bkls = map(B -> B[k,l], Bs)
+    for j = axes(A1, 2), l = axes(B1, 2), i = axes(A1, 1)
+        Aijs = map(A -> A[i, j], As)
+        for k = 1:size(Bs[1], 1)
+            Bkls = map(B -> B[k, l], Bs)
             Aijs_times_Bkls = map(*, Aijs, Bkls)
-            C[m += 1] = f(Aijs_times_Bkls...)
+            C[m+=1] = f(Aijs_times_Bkls...)
         end
     end
     return C
@@ -454,7 +454,7 @@ function Base.:-(A::StridedMatrix, B::AbstractKroneckerProduct)
     return C
 end
 
-const KronProdDiagonal = KroneckerProduct{<:Any, <:Diagonal, <:Diagonal}
+const KronProdDiagonal = KroneckerProduct{<:Any,<:Diagonal,<:Diagonal}
 for T in [:Diagonal, :UniformScaling]
     @eval Base.:+(K::KronProdDiagonal, D::$T) = Diagonal(K) + D
     @eval Base.:+(D::$T, K::KronProdDiagonal) = D + Diagonal(K)
@@ -492,7 +492,7 @@ function Base.kron(A::AbstractMatrix, K::AbstractKroneckerProduct)
 end
 
 Base.kron(K1::AbstractKroneckerProduct,
-            K2::AbstractKroneckerProduct) = kron(collect(K1), collect(K2))
+    K2::AbstractKroneckerProduct) = kron(collect(K1), collect(K2))
 
 # mixed-product property
 function Base.:*(K1::AbstractKroneckerProduct, K2::AbstractKroneckerProduct)
@@ -559,6 +559,24 @@ function LinearAlgebra.svdvals(K::KroneckerProduct)
     return σ
 end
 
+# Special method to construct a kronecker product of Diagonals
+# See https://github.com/MichielStock/Kronecker.jl/pull/113#issuecomment-1024920775
+"""
+    diagonal(A::AbstractMatrix)
+
+Construct a diagonal matrix with the principal diagonal being `diag(A)`.
+"""
+diagonal(A::AbstractMatrix) = Diagonal(A)
+function diagonal(K::AbstractKroneckerProduct)
+    mats = getmatrices(K)
+    if !all(issquare, mats)
+        throw(ArgumentError(
+            "Kronecker product of non-square matrices provided, " *
+            "consider using LinearAlgbera.Diagonal instead"))
+    end
+    mapreduce(diagonal, ⊗, mats)
+end
+
 # Broadcasting machinery
 
 Base.copyto!(dest::AbstractMatrix, K::AbstractKroneckerProduct) = collect!(dest, K)
@@ -583,17 +601,21 @@ end
         A = bc.args[1]
         collect!(bc.f, dest, A)
         return dest
-    # Case 2, example: 2 .* B
-    elseif bc.args isa Tuple{Number, AbstractKroneckerProduct}
+        # Case 2, example: 2 .* B
+    elseif bc.args isa Tuple{Number,AbstractKroneckerProduct}
         A = last(bc.args)
         n = first(bc.args)
-        collect!(let n = n; x -> bc.f(n, x); end, dest, A)
+        collect!(let n = n
+            x -> bc.f(n, x)
+        end, dest, A)
         return dest
-    # Case 3, example: B .* 2
-    elseif bc.args isa Tuple{AbstractKroneckerProduct, Number}
+        # Case 3, example: B .* 2
+    elseif bc.args isa Tuple{AbstractKroneckerProduct,Number}
         A = first(bc.args)
         n = last(bc.args)
-        collect!(let n = n; x -> bc.f(x, n); end, dest, A)
+        collect!(let n = n
+            x -> bc.f(x, n)
+        end, dest, A)
         return dest
     end
     # An operation like K1 .+ K2 may be short-circuited if the component matrices
@@ -605,7 +627,7 @@ end
             collect!(bcf.f, dest, bcf.args...)
             return dest
         end
-    elseif all(x -> x isa Union{AbstractKroneckerProduct, StridedArray}, bcf.args)
+    elseif all(x -> x isa Union{AbstractKroneckerProduct,StridedArray}, bcf.args)
         # Performance is better if the kronecker products are collected before the
         # broadcasted operation is performed, although this incurs allocations
         broadcast!(bcf.f, dest, map(_maybecollect, bcf.args)...)

--- a/src/vectrick.jl
+++ b/src/vectrick.jl
@@ -12,7 +12,7 @@ Vec trick: multiplying vectors with Kronecker systems.
 import Base.ReshapedArray
 
 vectrick_reshape(v::AbstractVector, d::Int, b::Int) = reshape(v, d, b)
-function vectrick_reshape(v::ReshapedArray{<:Any, 1}, d::Int, b::Int)
+function vectrick_reshape(v::ReshapedArray{<:Any,1}, d::Int, b::Int)
     return size(v.parent) == (d, b) ? v.parent : reshape(v, d, b)
 end
 
@@ -112,7 +112,7 @@ function ldiv_vec_trick!(X::AbstractMatrix, A::AbstractKroneckerProduct, V::Abst
 end
 
 
-function check_compatible_sizes(C::AbstractVecOrMat, A::AbstractMatrix, B::AbstractVecOrMat, mul=true)
+function check_compatible_sizes(C::AbstractVecOrMat, A::AbstractMatrix, B::AbstractVecOrMat, mul = true)
     # when performing a division (mul=false), A acts as a matrix with reversed dimensions
     m, n = mul ? size(A) : reverse(size(A))
 
@@ -143,7 +143,7 @@ function mul!(C::AbstractMatrix, D::Diagonal, A::AbstractKroneckerProduct)
 end
 
 for TC in [:AbstractVector, :AbstractMatrix],
-    TB in [:($TC), :(Transpose{T, <:$TC{T}} where T), :(Adjoint{T, <:$TC{T}} where T)]
+    TB in [:($TC), :(Transpose{T,<:$TC{T}} where {T}), :(Adjoint{T,<:$TC{T}} where {T})]
 
     @eval function mul!(C::$TC, A::AbstractKroneckerProduct, B::$TB)
         check_compatible_sizes(C, A, B)
@@ -216,12 +216,12 @@ function Base.:*(v::AbstractMatrix, K::GeneralizedKroneckerProduct)
     return transpose(mul!(out, transpose(K), transpose(v)))
 end
 
-function Base.:*(v::Adjoint{<:Number, <:AbstractVector}, K::GeneralizedKroneckerProduct)
+function Base.:*(v::Adjoint{<:Number,<:AbstractVector}, K::GeneralizedKroneckerProduct)
     out = Vector{promote_type(eltype(v), eltype(K))}(undef, last(size(K)))
     return mul!(out, K', v.parent)'
 end
 
-function Base.:*(v::Transpose{<:Number, <:AbstractVector}, K::GeneralizedKroneckerProduct)
+function Base.:*(v::Transpose{<:Number,<:AbstractVector}, K::GeneralizedKroneckerProduct)
     out = Vector{promote_type(eltype(v), eltype(K))}(undef, last(size(K)))
     return transpose(mul!(out, transpose(K), v.parent))
 end
@@ -229,16 +229,17 @@ end
 # special multiplication methods for Kronecker products of Diagonal matrices
 # It's usually better to convert these to Diagonal to use optimized multiplication methods
 # instead of using the vec trick
-const KroneckerDiagonal = Union{KronProdDiagonal, KronPowDiagonal}
+const KroneckerDiagonal = Union{KronProdDiagonal,KronPowDiagonal}
 Base.:*(K::KroneckerDiagonal, v::AbstractVector) = Diagonal(K) * v
-Base.:*(K1::KroneckerDiagonal, K2::KroneckerDiagonal) = kronecker(map(*, getallfactors(K1), getallfactors(K2))...)
-for T in [MulMatTypes; :AbstractMatrix]
+for T in [MulMatTypes; :AbstractMatrix; :AbstractKroneckerProduct]
     @eval Base.:*(K::KroneckerDiagonal, D::$T) = Diagonal(K) * D
     @eval Base.:*(D::$T, K::KroneckerDiagonal) = D * Diagonal(K)
 end
+# ambiguity fix
+Base.:*(K1::KroneckerDiagonal, K2::KroneckerDiagonal) = Diagonal(K1) * Diagonal(K2)
 
 for T in [:Adjoint, :Transpose]
-    @eval Base.:*(A::$T{<:Number, <:AbstractVector}, K::KroneckerDiagonal) = A * Diagonal(K)
+    @eval Base.:*(A::$T{<:Number,<:AbstractVector}, K::KroneckerDiagonal) = A * Diagonal(K)
 end
 
 function LinearAlgebra.:\(K::AbstractKroneckerProduct, v::AbstractVector)
@@ -249,13 +250,13 @@ function LinearAlgebra.:\(K::AbstractKroneckerProduct, v::AbstractMatrix)
     return ldiv!(Matrix{promote_type(eltype(v), eltype(K))}(undef, last(size(K)), last(size(v))), K, v)
 end
 
-function Base.sum(K::AbstractKroneckerProduct; dims::Union{Nothing,Int}=nothing)
+function Base.sum(K::AbstractKroneckerProduct; dims::Union{Nothing,Int} = nothing)
     A, B = getmatrices(K)
     if dims === nothing
         s = zero(eltype(K))
         sumB = sum(B)
         return sum(sumB * A)
     else
-        return kronecker(sum(A, dims=dims), sum(B, dims=dims))
+        return kronecker(sum(A, dims = dims), sum(B, dims = dims))
     end
 end

--- a/test/testbase.jl
+++ b/test/testbase.jl
@@ -170,6 +170,16 @@
         @test_throws DimensionMismatch (A ⊗ D) * (C ⊗ B)
     end
 
+    @testset "diagonal" begin
+        local A = rand(2, 2) ⊗ rand(3, 3)
+        local AD = Kronecker.diagonal(A)
+        @test AD isa Kronecker.KroneckerProduct
+        @test AD == Diagonal(A) == Diagonal(collect(A))
+        @test Kronecker.diagonal(collect(A)) == Diagonal(A)
+        local B = rand(1, 2) ⊗ rand(1, 3)
+        @test_throws ArgumentError Kronecker.diagonal(B)
+    end
+
     @testset "Add to dense" begin
         @test K + X ≈ Matrix(K) + X
         @test X + K ≈ X + Matrix(K)

--- a/test/testbase.jl
+++ b/test/testbase.jl
@@ -1,9 +1,9 @@
 @testset "Kronecker products" begin
 
     A = randn(4, 4)
-    B = Array{Float64, 2}([1 2 3;
-         4 5 6;
-         7 -2 9])
+    B = Array{Float64,2}([1 2 3
+        4 5 6
+        7 -2 9])
     C = rand(5, 6)
     D = rand(4, 4)
 
@@ -104,12 +104,23 @@
         # test power_by_squaring
         local _m
         local K2
-        _m = reshape(1:4, 2,2)
+        _m = reshape(1:4, 2, 2)
         K2 = kronecker(_m, _m)
-        @test (@inferred K2^2) == K2*K2 == collect(K2)^2
+        @test (@inferred K2^2) == K2 * K2 == collect(K2)^2
 
         @test svdvals(K) ≈ svdvals(Kc) ≈ svdvals(X)
         @test rank(K) == rank(Kc) == rank(X)
+
+        # multiplication of kronecker product of Diagonal
+        Kd = Diagonal(A) ⊗ Diagonal(B)
+        DKd = Diagonal(Kd)
+        Kd2 = Diagonal(B) ⊗ Diagonal(A)
+        DKd2 = Diagonal(Kd2)
+        @test K * Kd ≈ X * DKd
+        @test Kd * K ≈ DKd * X
+        @test Kd * Kd ≈ DKd * DKd
+        @test Kd * Kd2 ≈ DKd * DKd2
+        @test Kd2 * Kd ≈ DKd2 * DKd
     end
 
     @testset "Mismatch errors" begin
@@ -132,7 +143,7 @@
         Kpow = ⊗(A, 5)
         @test order(Kpow) == 5
         @test size(Kpow, 1) == 4^5
-        @test Kpow[1,1] ≈ A[1,1]^5
+        @test Kpow[1, 1] ≈ A[1, 1]^5
     end
 
     @testset "kron" begin
@@ -140,8 +151,8 @@
         @test kron(A, B ⊗ C) ≈ kron(A, B, C)
         @test kron(A ⊗ B, C ⊗ D) ≈ kron(A, B, C, D)
         M = kron(A, B, C, D)
-        @test collect((A⊗B) ⊗ (C⊗D)) ≈ M
-        @test collect!(similar(M), (A⊗B) ⊗ (C⊗D)) ≈ M
+        @test collect((A ⊗ B) ⊗ (C ⊗ D)) ≈ M
+        @test collect!(similar(M), (A ⊗ B) ⊗ (C ⊗ D)) ≈ M
     end
 
     @testset "Mixed product" begin
@@ -189,10 +200,10 @@
 
         @testset "add/subtract digonal and kronecker product" begin
             local D1, K, Kc, D2
-            D1 = Diagonal(1:3);
-            K = kronecker(D1, D1);
-            Kc = collect(K);
-            D2 = kron(D1, D1);
+            D1 = Diagonal(1:3)
+            K = kronecker(D1, D1)
+            Kc = collect(K)
+            D2 = kron(D1, D1)
             @test K + D2 == Kc + D2
             @test D2 + K == D2 + Kc
             @test K + I == Kc + I
@@ -221,7 +232,7 @@
         Kc .= K
         @test all(Kc .== K)
         @test K .+ Kc .- K == K
-        Kv = @view K[:,:]
+        Kv = @view K[:, :]
         @test K .+ Kv == 2K
     end
 
@@ -245,9 +256,9 @@
         B = randn(m, m)
         K = A ⊗ B
         x = randn(n * m)
-        b = K*x
-        @test K\b ≈ x
-        @test (x'*K)/K ≈ x'
+        b = K * x
+        @test K \ b ≈ x
+        @test (x' * K) / K ≈ x'
 
         # testing least squares solution
         function test_ls_solve(size_A, size_B)
@@ -255,10 +266,10 @@
             B = randn(size_B)
             x = randn(size(A, 2) * size(B, 2))
             K = kronecker(A, B)
-            b = K*x
+            b = K * x
             b .+= randn(size(b)) # this moves b out of range(K), necessitating least-squares
-            xls = K\b
-            return K'*(K*xls) ≈ K'b # test via normal equations
+            xls = K \ b
+            return K' * (K * xls) ≈ K'b # test via normal equations
         end
 
         # 2) kronecker product is square, but A, B aren't


### PR DESCRIPTION
Fixes the following multiplications:

```julia
julia> A = randn(4, 4);

julia> B = Array{Float64, 2}([1 2 3;
                4 5 6;
                7 -2 9]);

julia> K = A ⊗ B;

julia> Kd = Diagonal(A) ⊗ Diagonal(B);

julia> Kd2 = Diagonal(B) ⊗ Diagonal(A);

julia> Kd * Kd2 ≈ Diagonal(Kd) * Diagonal(Kd2)
true

julia> Kd2 * Kd ≈ Diagonal(Kd2) * Diagonal(Kd)
true

julia> K * Kd ≈ collect(K) * Diagonal(Kd)
true

julia> Kd * K ≈ Diagonal(Kd) * collect(K)
true
```