### PR TITLE
Sum and diff of Diagonal Kronecker products

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Kronecker"
 uuid = "2c470bb0-bcc8-11e8-3dad-c9649493f05e"
 authors = ["MichielStock <michielfmstock@gmail.com>"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/base.jl
+++ b/src/base.jl
@@ -461,7 +461,7 @@ end
 
 # some tricks to preferentially negate structured matrices
 supportsfastnegation(::AbstractMatrix) = false
-supportsfastnegation(::Union{Diagonal, Bidiagonal, Tridiagonal, SymTridiagonal}) = true
+supportsfastnegation(::Union{Diagonal,Bidiagonal,Tridiagonal,SymTridiagonal}) = true
 supportsfastnegation(A::AbstractKroneckerProduct) = all(supportsfastnegation, getmatrices(A))
 
 function Base.:-(K::AbstractKroneckerProduct)
@@ -619,7 +619,7 @@ end
         A = bc.args[1]
         collect!(bc.f, dest, A)
         return dest
-        # Case 2, example: 2 .* B
+    # Case 2, example: 2 .* B
     elseif bc.args isa Tuple{Number,AbstractKroneckerProduct}
         A = last(bc.args)
         n = first(bc.args)
@@ -627,7 +627,7 @@ end
             x -> bc.f(n, x)
         end, dest, A)
         return dest
-        # Case 3, example: B .* 2
+    # Case 3, example: B .* 2
     elseif bc.args isa Tuple{AbstractKroneckerProduct,Number}
         A = first(bc.args)
         n = last(bc.args)

--- a/src/kroneckerpowers.jl
+++ b/src/kroneckerpowers.jl
@@ -41,6 +41,7 @@ type.
 getallfactors(K::KroneckerPower) = ntuple(_ -> K.A, K.pow)
 
 getmatrices(K::KroneckerPower) = (K.pow == 2 ? K.A : KroneckerPower(K.A, K.pow - 1), K.A)
+
 lastmatrix(K::KroneckerPower) = K.A
 
 order(K::KroneckerPower) = K.pow
@@ -151,18 +152,24 @@ function Base.:*(K1::KroneckerPower, K2::KroneckerPower)
     K1.pow == K2.pow || throw(ArgumentError("multiplication is only defined if all terms have the same exponent"))
     _mulmixed(K1, K2)
 end
+
 const KronPowDiagonal = KroneckerPower{<:Any,<:Diagonal}
+const KroneckerDiagonal = Union{KronProdDiagonal,KronPowDiagonal}
+
 function Base.:*(K1::KronPowDiagonal, K2::KronPowDiagonal)
     K1.pow == K2.pow || throw(ArgumentError("multiplication is only defined if all terms have the same exponent"))
     _mulmixed(K1, K2)
 end
 
 for T in [:Diagonal, :UniformScaling]
-    @eval Base.:+(K::KronPowDiagonal, D::$T) = Diagonal(K) + D
-    @eval Base.:+(D::$T, K::KronPowDiagonal) = D + Diagonal(K)
-    @eval Base.:-(K::KronPowDiagonal, D::$T) = Diagonal(K) - D
-    @eval Base.:-(D::$T, K::KronPowDiagonal) = D - Diagonal(K)
+    @eval Base.:+(K::KroneckerDiagonal, D::$T) = Diagonal(K) + D
+    @eval Base.:+(D::$T, K::KroneckerDiagonal) = D + Diagonal(K)
+    @eval Base.:-(K::KroneckerDiagonal, D::$T) = Diagonal(K) - D
+    @eval Base.:-(D::$T, K::KroneckerDiagonal) = D - Diagonal(K)
 end
+
+Base.:+(K1::KroneckerDiagonal, K2::KroneckerDiagonal) = Diagonal(K1) + Diagonal(K2)
+Base.:-(K1::KroneckerDiagonal, K2::KroneckerDiagonal) = Diagonal(K1) - Diagonal(K2)
 
 """
     lmul!(a::Number, K::KroneckerPower)

--- a/src/vectrick.jl
+++ b/src/vectrick.jl
@@ -223,7 +223,6 @@ end
 # special multiplication methods for Kronecker products of Diagonal matrices
 # It's usually better to convert these to Diagonal to use optimized multiplication methods
 # instead of using the vec trick
-const KroneckerDiagonal = Union{KronProdDiagonal,KronPowDiagonal}
 Base.:*(K::KroneckerDiagonal, v::AbstractVector) = Diagonal(K) * v
 for T in [MulMatTypes; :AbstractMatrix; :AbstractKroneckerProduct]
     @eval Base.:*(K::KroneckerDiagonal, D::$T) = Diagonal(K) * D

--- a/test/testbase.jl
+++ b/test/testbase.jl
@@ -262,6 +262,11 @@
             @test D2 - K == D2 - Kc
             @test I - K == I - Kc
             @test K - I == Kc - I
+
+            local K3
+            K3 = kronecker(D1, 3)
+            @test K3 + Diagonal(K3) == Diagonal(K3) + K3 == 2Diagonal(K3)
+            @test K3 - Diagonal(K3) == Diagonal(K3) - K3 == K3 - K3 == zero(Diagonal(K3))
         end
     end
 

--- a/test/testbase.jl
+++ b/test/testbase.jl
@@ -248,6 +248,20 @@
             @test K34 + K43 == K43 + K34 == Diagonal(K34) + Diagonal(K43)
             @test K33 + K33 == 2K33 == 2Diagonal(K33)
             @test K34 + K34 == 2K34 == 2Diagonal(K34)
+
+            local D1, K, Kc, D2
+            D1 = Diagonal(1:3)
+            K = kronecker(D1, D1)
+            Kc = collect(K)
+            D2 = kron(D1, D1)
+            @test K + D2 == Kc + D2
+            @test D2 + K == D2 + Kc
+            @test K + I == Kc + I
+            @test I + K == I + Kc
+            @test K - D2 == Kc - D2
+            @test D2 - K == D2 - Kc
+            @test I - K == I - Kc
+            @test K - I == Kc - I
         end
     end
 

--- a/test/testbase.jl
+++ b/test/testbase.jl
@@ -225,19 +225,29 @@
         @test K34 - K43 ≈ collect(K34) - collect(K43)
 
         @testset "add/subtract digonal and kronecker product" begin
-            local D1, K, Kc, D2
-            D1 = Diagonal(1:3)
-            K = kronecker(D1, D1)
-            Kc = collect(K)
-            D2 = kron(D1, D1)
-            @test K + D2 == Kc + D2
-            @test D2 + K == D2 + Kc
-            @test K + I == Kc + I
-            @test I + K == I + Kc
-            @test K - D2 == Kc - D2
-            @test D2 - K == D2 - Kc
-            @test I - K == I - Kc
-            @test K - I == Kc - I
+            local D3, D4, K33, K34, K43, M33, M34, D33, D34
+            D3 = Diagonal(1:3)
+            D4 = Diagonal(1:4)
+            K33 = kronecker(D3, D3)
+            K34 = kronecker(D3, D4)
+            K43 = kronecker(D4, D3)
+            M33 = collect(K33)
+            M34 = collect(K34)
+            D33 = kron(D3, D3)
+            D34 = kron(D3, D4)
+            @test K33 + D33 == M33 + D33
+            @test D33 + K33 == D33 + M33
+            @test D34 + K34 == D34 + M34
+            @test K33 + I == I + K33 == D33 + I
+            @test K34 + I == I + K34 == D34 + I
+            @test K33 - D33 == M33 - D33
+            @test D33 - K33 == D33 - M33
+            @test I - K33 == I - D33
+            @test I - K34 == I - D34
+            @test K33 - I == D33 - I
+            @test K34 + K43 == K43 + K34 == Diagonal(K34) + Diagonal(K43)
+            @test K33 + K33 == 2K33 == 2Diagonal(K33)
+            @test K34 + K34 == 2K34 == 2Diagonal(K34)
         end
     end
 

--- a/test/testkroneckersum.jl
+++ b/test/testkroneckersum.jl
@@ -31,7 +31,7 @@
 
         kronsum3 = kron(A, IB, IC) + kron(IA, B, IC) + kron(IA, IB, C)
 
-        for ks3 in [KS3, KS3AB, KS3BC]
+        for ks3 in (KS3, KS3AB, KS3BC)
             @test collect(ks3) ≈ kronsum3
             @test collect(ks3) isa AbstractSparseMatrix
             @test order(ks3) == 3

--- a/test/testmultiply.jl
+++ b/test/testmultiply.jl
@@ -1,5 +1,5 @@
-A = rand(3, 3)
-B = ones(Int, 4, 4)
+A = rand(3, 3) + 1e-2I
+B = ones(Int, 4, 4) + I
 C = randn(5, 6)
 K = A ⊗ B
 X = collect(K)


### PR DESCRIPTION
This PR converts kronecker products of `Diagonal` matrices to `Diagonal`, therefore using optimized arithmetic methods instead of converting to a `Matrix`.

On mater:
```julia
julia> A = Diagonal([1:3;])
3×3 Diagonal{Int64, Vector{Int64}}:
 1  ⋅  ⋅
 ⋅  2  ⋅
 ⋅  ⋅  3

julia> B = Diagonal([1:2;])
2×2 Diagonal{Int64, Vector{Int64}}:
 1  ⋅
 ⋅  2

julia> Kd = kronecker(A, B)
6×6 Kronecker.KroneckerProduct{Int64, Diagonal{Int64, Vector{Int64}}, Diagonal{Int64, Vector{Int64}}}:
 1  0  0  0  0  0
 0  2  0  0  0  0
 0  0  2  0  0  0
 0  0  0  4  0  0
 0  0  0  0  3  0
 0  0  0  0  0  6

julia> Kd + Kd
6×6 Matrix{Int64}:
 2  0  0  0  0   0
 0  4  0  0  0   0
 0  0  4  0  0   0
 0  0  0  8  0   0
 0  0  0  0  6   0
 0  0  0  0  0  12
```

This PR:
```julia
julia> Kd + Kd
6×6 Diagonal{Int64, Vector{Int64}}:
 2  ⋅  ⋅  ⋅  ⋅   ⋅
 ⋅  4  ⋅  ⋅  ⋅   ⋅
 ⋅  ⋅  4  ⋅  ⋅   ⋅
 ⋅  ⋅  ⋅  8  ⋅   ⋅
 ⋅  ⋅  ⋅  ⋅  6   ⋅
 ⋅  ⋅  ⋅  ⋅  ⋅  12
```

Negation is not covered in this PR, but that should be covered in #111 