### PR TITLE
Increase performace by skiping initialization of temp arrays

### DIFF
--- a/src/indexedkroncker.jl
+++ b/src/indexedkroncker.jl
@@ -80,7 +80,7 @@ function genvectrick!(M, N, v, u, p, q, r, t)
     u .= 0  # reset for inplace
     if a * e + d * f < c * e + b * f
         # compute T = VM'
-        T = zeros(eltype(v), d, a)
+        T = similar(v, (d, a))
         @simd for h in 1:e
             i, j = r[h], t[h]
             @simd for k in 1:a
@@ -95,7 +95,7 @@ function genvectrick!(M, N, v, u, p, q, r, t)
         end
     else
         # compute S = NV
-        S = zeros(eltype(v), d, a)
+        S = similar(v, (d, a))
         @simd for h in 1:e
             i, j = r[h], t[h]
             @simd for k in 1:c
@@ -115,7 +115,7 @@ end
 function genvectrick(M, N, v, p, q, r, t)
     # computes N ⊗ M
     f = length(p)
-    u = zeros(eltype(v), f)
+    u = similar(v, (f))
     return genvectrick!(M, N, v, u, p, q, r, t)
 end
 

--- a/src/multiply.jl
+++ b/src/multiply.jl
@@ -1,5 +1,5 @@
-@inline _alloc_temp_array(size_1::Int, x::AbstractVector{T}) where {T} = zeros(T, size_1)
-@inline _alloc_temp_array(size_1::Int, x::AbstractMatrix{T}) where {T} = zeros(T, size_1, size(x, 2))
+@inline _alloc_temp_array(size_1::Int, x::AbstractVector{T}) where {T} = similar(x, (size_1))
+@inline _alloc_temp_array(size_1::Int, x::AbstractMatrix{T}) where {T} = similar(x, (size_1, size(x, 2)))
 
 const MatrixOrFactorization{T} = Union{AbstractMatrix{T},Factorization{T}}
 


### PR DESCRIPTION
Using `similar` instead of `zeros` should be more performant since we do
not use the fact that there are zeros (arrays are only used as storage)
and `similar` does not initialize the arrays, but only allocates memory
for them.
