### PR TITLE
:ambulance: fix diag multiple issue

### DIFF
--- a/src/vectrick.jl
+++ b/src/vectrick.jl
@@ -227,12 +227,12 @@ end
 # It's usually better to convert these to Diagonal to use optimized multiplication methods
 # instead of using the vec trick
 Base.:*(K::KroneckerDiagonal, v::AbstractVector) = Diagonal(K) * v
-for T in [MulMatTypes; :AbstractMatrix; :AbstractKroneckerProduct]
+for T in MulMatTypes
     @eval Base.:*(K::KroneckerDiagonal, D::$T) = Diagonal(K) * D
     @eval Base.:*(D::$T, K::KroneckerDiagonal) = D * Diagonal(K)
 end
 # ambiguity fix
-Base.:*(K1::KroneckerDiagonal, K2::KroneckerDiagonal) = Diagonal(K1) * Diagonal(K2)
+#Base.:*(K1::KroneckerDiagonal, K2::KroneckerDiagonal) = Diagonal(K1) * Diagonal(K2)
 
 for T in [:Adjoint, :Transpose]
     @eval Base.:*(A::$T{<:Number,<:AbstractVector}, K::KroneckerDiagonal) = A * Diagonal(K)

--- a/test/testbase.jl
+++ b/test/testbase.jl
@@ -127,8 +127,8 @@
         @test K * Kd ≈ X * DKd
         @test Kd * K ≈ DKd * X
         @test Kd * Kd ≈ DKd * DKd
-        @test Kd * Kd2 ≈ DKd * DKd2
-        @test Kd2 * Kd ≈ DKd2 * DKd
+        @test Diagonal(Kd) * Kd2 ≈ DKd * DKd2
+        @test Kd2 * Diagonal(Kd) ≈ DKd2 * DKd
     end
 
     @testset "Mismatch errors" begin


### PR DESCRIPTION
This addresses #124

The problem was that Kronecker products of diagonal matrices are transformed too eagerly in `Diagonal` types.
I fixed this by making the methods less general. This had the issue that it errors in a couple of test cases when the mixed product property is non-conformable. Within the philosophy of Kronecker.jl, it is your responsibility to fix this, e.g. by making one of the matrices dense.