### PR TITLE
Add a `Base.copy!` implementation

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -152,6 +152,11 @@ size(K::GeneralizedKroneckerProduct, dim::Integer) = size(K)[dim]
 
 Base.copy(K::AbstractKroneckerProduct) = kronecker(copy(K.A), copy(K.B))
 Base.deepcopy(K::AbstractKroneckerProduct) = kronecker(deepcopy(K.A), deepcopy(K.B))
+Base.copy!(K1::AbstractKroneckerProduct, K2::AbstractKroneckerProduct) = begin
+	  Base.copy!(K1.A, K2.A)
+	  Base.copy!(K1.B, K2.B)
+    return K1
+end
 
 Base.similar(K::AbstractKroneckerProduct) = kronecker(similar(K.A), similar(K.B))
 

--- a/src/kroneckersum.jl
+++ b/src/kroneckersum.jl
@@ -14,6 +14,11 @@ end
 Base.copy(K::KroneckerSum) = kroneckersum(copy(K.A), copy(K.B))
 Base.deepcopy(K::KroneckerSum) = kroneckersum(deepcopy(K.A), deepcopy(K.B))
 Base.similar(K::KroneckerSum) = kroneckersum(similar(K.A), similar(K.B))
+Base.copy!(K1::KroneckerSum, K2::KroneckerSum) = begin
+    Base.copy!(K1.A, K2.A)
+    Base.copy!(K1.B, K2.B)
+    return K1
+end
 
 order(M::AbstractKroneckerSum) = order(M.A) + order(M.B)
 issquare(M::AbstractKroneckerSum) = true

--- a/test/testbase.jl
+++ b/test/testbase.jl
@@ -50,6 +50,10 @@
         @test Kcopy isa AbstractKroneckerProduct
 
         @test similar(K) isa AbstractKroneckerProduct
+
+        Kcopy = similar(A) ⊗ similar(B)
+        @test_nowarn copy!(Kcopy, K)
+        @test Kcopy ≈ K
     end
 
     @testset "Using vectors" begin

--- a/test/testkroneckersum.jl
+++ b/test/testkroneckersum.jl
@@ -24,13 +24,17 @@
 
         @test issquare(KS)
 
-        @test copy(KS) isa KroneckerSum 
+        @test copy(KS) isa KroneckerSum
 
         KScopy = deepcopy(KS)
         @test KScopy ≈ KS
         @test KScopy isa KroneckerSum
 
         @test similar(KS) isa KroneckerSum
+
+        KScopy = similar(A) ⊕ similar(B)
+        @test_nowarn copy!(KScopy, KS)
+        @test KScopy ≈ KS
 
         IC = oneunit(C)
         KS3 = A ⊕ B ⊕ C


### PR DESCRIPTION
This PR implements `Base.copy!` for `AbstractKroneckerProduct` and `KroneckerSum`.

I did not include a version for `KroneckerPower` since I'm not sure how this should best be handled, as the power is a non-mutable field of a struct. Therefore an in-place change does not really make sense.