### PR TITLE
Relax kroneckersum test

### DIFF
--- a/test/testkroneckersum.jl
+++ b/test/testkroneckersum.jl
@@ -76,7 +76,7 @@
         B = rand(10, 10)
         V = Diagonal(rand(10))
         @testset "Vec trick for sums" begin
-            @test (A ⊕ B) * vec(V) == vec(B * V + V * transpose(A))
+            @test (A ⊕ B) * vec(V) ≈ vec(B * V + V * transpose(A))
         end
 
         A = rand(3, 3)


### PR DESCRIPTION
This came up in a pkgeval run in https://github.com/JuliaLang/julia/pull/52038. I don't think exact equality can be expected here with floating point numbers, so I propose to relax this test. Another option could be to use integer matrices upfront.