### PR TITLE
Phase 2: dependency slimming via package extensions (release 0.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,28 @@
 
 All notable changes to Kronecker.jl are documented in this file.
 
-## Unreleased
+## Version 0.6.0
+
+### Breaking
+
+- The minimum supported Julia version is now 1.10 (was 1.0).
+- NamedDims.jl support is now a package extension: NamedDims is a weak
+  dependency, so users must load NamedDims themselves (`using NamedDims`) to
+  activate the `NamedDimsArray` methods. Behaviour once loaded is unchanged.
+- StatsBase.jl is no longer a dependency; weighted sampling for Kronecker
+  graphs is implemented internally. The hard dependencies of the package are
+  now LinearAlgebra, Random and SparseArrays only.
+
+### Added
+
+- `naivesample`, `fastsample` and `sampleindices` accept an optional leading
+  `rng::AbstractRNG` argument (default `Random.default_rng()`), making
+  Kronecker graph sampling reproducible.
 
 ### Changed
 
-- The minimum supported Julia version is now 1.10 (was 1.0).
+- Documentation migrated to Documenter 1.x, building in strict mode with
+  doctests enabled; several missing docstrings added.
 - Removed the pre-Julia-1.3 compatibility branch for five-argument `mul!` in `src/vectrick.jl`.
 - Continuous integration modernised: current action versions (`actions/checkout@v4`, `julia-actions/setup-julia@v2`, `codecov/codecov-action@v5`), package caching via `julia-actions/cache@v2`, test matrix now covers Julia 1.10 (LTS), the latest stable release, and pre-releases. Coverage upload now requires the `CODECOV_TOKEN` repository secret.
 - Added Dependabot configuration to keep GitHub Actions up to date.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,22 @@ All notable changes to Kronecker.jl are documented in this file.
 - Continuous integration modernised: current action versions (`actions/checkout@v4`, `julia-actions/setup-julia@v2`, `codecov/codecov-action@v5`), package caching via `julia-actions/cache@v2`, test matrix now covers Julia 1.10 (LTS), the latest stable release, and pre-releases. Coverage upload now requires the `CODECOV_TOKEN` repository secret.
 - Added Dependabot configuration to keep GitHub Actions up to date.
 - Aqua.jl quality checks updated to Aqua 0.8 with method-ambiguity checking re-enabled.
+- `sampleindices` on a Kronecker product is faster (single flat walk over the
+  factors with preallocated buffers instead of a pairwise recursion; weights of
+  a repeated `KroneckerPower` factor are computed once). The sampling
+  distribution is unchanged and pinned by tests against the dense `kron`
+  distribution.
+- `isprob` no longer allocates (predicate-based `all` instead of broadcasting).
 
 ### Fixed
 
+- `fastsample` systematically produced fewer edges than the expected count
+  `sum(P)`: indices were drawn with replacement and duplicates collapsed into a
+  single edge. Collisions are now re-sampled, as in Leskovec et al. (2008), so
+  the graph contains exactly `round(Int, sum(P))` edges. Note that graphs
+  sampled with a given seed differ from those of version 0.5.x.
+- `_sample_weighted` and `sampleindices` now throw an `ArgumentError` for
+  negative weights, which would previously corrupt the sampling silently.
 - `IndexedKroneckerProduct` multiplication (`genvectrick!`) could return garbage or `NaN`: its scratch array was accumulated into without zero-initialisation, so results depended on heap state. The second ("S = NV") branch additionally used wrong scratch dimensions and a wrong index, writing out of bounds under `@inbounds`. Both branches are fixed and covered by seeded regression tests.
 - Renamed `src/indexedkroncker.jl` to `src/indexedkronecker.jl` and `scrips/` to `scripts/` (typos).
 - README fixes: "comparision" → "comparison", updated benchmark script link, added a "Citing" section for the JuliaCon proceedings paper.

--- a/Project.toml
+++ b/Project.toml
@@ -5,9 +5,14 @@ version = "0.5.5"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-NamedDims = "356022a1-0364-5f58-8944-0da4b18d706f"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+
+[weakdeps]
+NamedDims = "356022a1-0364-5f58-8944-0da4b18d706f"
+
+[extensions]
+KroneckerNamedDimsExt = "NamedDims"
 
 [compat]
 Aqua = "0.8"
@@ -16,16 +21,16 @@ NamedDims = "0.2, 0.3, 1"
 PkgBenchmark = "0.2"
 Random = "1.10"
 SparseArrays = "1.10"
-StatsBase = "0.32, 0.33, 0.34"
 Test = "1.10"
 julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+NamedDims = "356022a1-0364-5f58-8944-0da4b18d706f"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 benchmark = ["PkgBenchmark"]
-test = ["Aqua", "Random", "Test"]
+test = ["Aqua", "NamedDims", "Random", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Kronecker"
 uuid = "2c470bb0-bcc8-11e8-3dad-c9649493f05e"
 authors = ["MichielStock <michielfmstock@gmail.com>"]
-version = "0.5.5"
+version = "0.6.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,5 +4,5 @@ Kronecker = "2c470bb0-bcc8-11e8-3dad-c9649493f05e"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
-Documenter = "0.25, 0.26, 0.27"
-Kronecker = "0.5"
+Documenter = "1"
+Kronecker = "0.5, 0.6"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,15 +1,3 @@
-#=
-using Pkg
-
-tmp_packages = ["Kronecker", "Documenter"]
-
-push!(LOAD_PATH,"../src/")
-
-Pkg.activate(".")
-
-Pkg.add.(tmp_packages) # IMPORTANT
-=#
-
 using Documenter, Kronecker, LinearAlgebra
 
 makedocs(
@@ -17,6 +5,8 @@ makedocs(
     authors = "Michiel Stock",
     format = Documenter.HTML(),
     modules = [Kronecker],
+    checkdocs = :exports,
+    doctest = true,
     pages = Any[
         "Basic use" => "man/basic.md",
         "Types" => "man/types.md",
@@ -30,4 +20,5 @@ makedocs(
 
 deploydocs(
     repo = "github.com/MichielStock/Kronecker.jl.git",
+    push_preview = false,
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,7 +10,7 @@ Commonly-used mathematical functions are overloaded to provide the most efficien
 Pages = [
     "man/basic.md",
     "man/types.md",
-    "man/multiplication.md"
+    "man/multiplication.md",
     "man/factorization.md",
     "man/indexed.md",
     "man/kroneckersums.md",

--- a/docs/src/man/basic.md
+++ b/docs/src/man/basic.md
@@ -61,4 +61,5 @@ inv(K::AbstractKroneckerProduct)
 adjoint(K::AbstractKroneckerProduct)
 transpose(K::AbstractKroneckerProduct)
 conj(K::AbstractKroneckerProduct)
+isposdef(K::AbstractKroneckerProduct)
 ```

--- a/docs/src/man/factorization.md
+++ b/docs/src/man/factorization.md
@@ -30,8 +30,6 @@ b = randn(40);
 ```@docs
 eigen
 +(E::Eigen, B::UniformScaling)
-+(::Eigen, ::UniformScaling)
-
 det(E::Eigen{<:Number, <:Number, <:AbstractKroneckerProduct})
 logdet(E::Eigen{<:Number, <:Number, <:AbstractKroneckerProduct})
 inv(E::Eigen{<:Number, <:Number, <:AbstractKroneckerProduct})

--- a/docs/src/man/kroneckerpowers.md
+++ b/docs/src/man/kroneckerpowers.md
@@ -20,6 +20,7 @@ K12^2  # example
 ```
 
 ```@docs
+KroneckerPower
 kronecker(A::AbstractMatrix, pow::Int)
 ⊗(A::AbstractMatrix, pow::Int)
 ```
@@ -47,4 +48,5 @@ A = fastsample(P10)
 isprob
 naivesample
 fastsample
+sampleindices
 ```

--- a/docs/src/man/kroneckersums.md
+++ b/docs/src/man/kroneckersums.md
@@ -25,5 +25,4 @@ kroneckersum
 ⊕
 collect(K::AbstractKroneckerSum)
 exp
-mul!(x::AbstractVector, K::AbstractKroneckerSum, v::AbstractVector)
 ```

--- a/docs/src/man/multiplication.md
+++ b/docs/src/man/multiplication.md
@@ -51,7 +51,7 @@ The vec trick works with higher-order Kronecker products. **However, at the mome
 ## Docstrings
 
 ```@docs
-mul!
+Kronecker.mul_vec_trick!
 lmul!
 rmul!
 ```

--- a/ext/KroneckerNamedDimsExt.jl
+++ b/ext/KroneckerNamedDimsExt.jl
@@ -1,0 +1,35 @@
+module KroneckerNamedDimsExt
+
+using Kronecker, NamedDims
+using Kronecker: KroneckerProduct, IndexedKroneckerProduct, KroneckerDiagonal,
+    kron_names
+import Kronecker: kronecker
+
+# Re-wrap with names:
+kronecker(A::NamedDimsArray{L1}, B::NamedDimsArray{L2}) where {L1,L2} =
+    NamedDimsArray(KroneckerProduct(parent(A), parent(B)), kron_names(L1, L2))
+
+kronecker(A::NamedDimsArray{L}, B::AbstractMatrix) where {L} =
+    NamedDimsArray(KroneckerProduct(parent(A), B), kron_names(L, (:_, :_)))
+kronecker(A::AbstractMatrix, B::NamedDimsArray{L}) where {L} =
+    NamedDimsArray(KroneckerProduct(A, parent(B)), kron_names((:_, :_), L))
+
+# Power
+kronecker(A::NamedDimsArray{L}, p::Int) where {L} =
+    NamedDimsArray(kronecker(parent(A), p), kron_names(L, Val(p)))
+
+# Disambiguation between NamedDims' `*` methods (which dispatch on
+# NamedDimsArray operands) and the Kronecker vec-trick methods. The type
+# patterns mirror the signatures in NamedDims/src/functions_math.jl.
+const NamedVector = NamedDimsArray{L,T,1,A} where {L,T,A<:AbstractVector{T}}
+
+Base.:*(K::GeneralizedKroneckerProduct, v::NamedVector) = K * parent(v)
+Base.:*(K::IndexedKroneckerProduct, v::NamedVector) = K * parent(v)
+Base.:*(K::KroneckerDiagonal, v::NamedVector) = K * parent(v)
+
+Base.:*(K::GeneralizedKroneckerProduct, M::NamedDimsArray{L,T,2,A}) where {L,T,A<:AbstractMatrix{T}} =
+    NamedDimsArray(K * parent(M), (:_, last(L)))
+Base.:*(M::NamedDimsArray{L,T,2,A}, K::GeneralizedKroneckerProduct) where {L,T,A<:AbstractMatrix{T}} =
+    NamedDimsArray(parent(M) * K, (first(L), :_))
+
+end # module

--- a/src/base.jl
+++ b/src/base.jl
@@ -1,5 +1,11 @@
 abstract type GeneralizedKroneckerProduct{T} <: AbstractMatrix{T} end
 
+"""
+    eltype(K::GeneralizedKroneckerProduct)
+
+Return the type of the elements of a Kronecker product, i.e. the promoted type
+of the elements of its factors.
+"""
 Base.eltype(K::GeneralizedKroneckerProduct{T}) where {T} = T
 
 abstract type AbstractKroneckerProduct{T} <: GeneralizedKroneckerProduct{T} end
@@ -325,6 +331,12 @@ function Base.permutedims(K::AbstractKroneckerProduct)
     return kronecker(permutedims(A), permutedims(B))
 end
 
+"""
+    conj(K::AbstractKroneckerProduct)
+
+Compute the elementwise complex conjugate of a Kronecker product, lazily, as
+the Kronecker product of the conjugated factors.
+"""
 function Base.conj(K::AbstractKroneckerProduct)
     A, B = getmatrices(K)
     return kronecker(conj(A), conj(B))

--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -42,6 +42,13 @@ function LinearAlgebra.eigvals(K::AbstractKroneckerProduct; kw...)
     end
 end
 
+"""
+    +(E::Eigen, B::UniformScaling)
+
+Shift a spectral decomposition, i.e. `eigen(K) + λI` yields the (lazy)
+eigenvalue decomposition of `K + λI`. This can be used to efficiently solve
+systems of the form `(A ⊗ B + λI) \\ v`.
+"""
 +(E::Eigen, B::UniformScaling) = Eigen(E.values .+ B.λ, E.vectors)
 +(A::UniformScaling, E::Eigen) = E + A
 

--- a/src/kroneckergraphs.jl
+++ b/src/kroneckergraphs.jl
@@ -14,7 +14,7 @@ Retrieved from https://cs.stanford.edu/~jure/pubs/kronecker-jmlr10.pdf
 =#
 
 using SparseArrays: spzeros
-using StatsBase: sample, Weights
+using Random: AbstractRNG, default_rng
 
 """
     isprob(A::AbstractArray)
@@ -36,46 +36,60 @@ function isprob(K::AbstractKroneckerProduct)
 end
 
 """
-    naivesample(P::AbstractKroneckerProduct)
+    _sample_weighted(rng::AbstractRNG, items, weights, s::Int)
+
+Draw `s` elements from `items` with replacement, with probabilities
+proportional to `weights` (assumed non-negative).
+"""
+function _sample_weighted(rng::AbstractRNG, items, weights, s::Int)
+    cw = cumsum(weights)
+    total = last(cw)
+    total > 0 || throw(ArgumentError("weights must have a positive sum"))
+    return [items[searchsortedfirst(cw, rand(rng) * total)] for _ in 1:s]
+end
+
+"""
+    naivesample([rng::AbstractRNG,] P::AbstractKroneckerProduct)
 
 Sample a Kronecker graph from a probabilistic Kronecker product P using the
 naive method. This method has a time complexity in the size of the Kronecker
 product (but is still light in memory use). Consider using `fastsample`.
 """
-function naivesample(P::AbstractKroneckerProduct)
+function naivesample(rng::AbstractRNG, P::AbstractKroneckerProduct)
     @assert isprob(P) throw(DomainError(
         "All values of K should be between 0 and 1"))
     G = spzeros(Bool, size(P)...)
     for I in CartesianIndices(P)
-        if P[I] > rand()  # QUESTION: is this the most efficient way?
+        if P[I] > rand(rng)  # QUESTION: is this the most efficient way?
             @inbounds G[I] = true
         end
     end
     return G
 end
 
+naivesample(P::AbstractKroneckerProduct) = naivesample(default_rng(), P)
+
 """
-    sampleindices(A::AbstractMatrix, s::Int)
+    sampleindices([rng::AbstractRNG,] A::AbstractMatrix, s::Int)
 
 Samples the indices from an `AbstractMatrix`. Probability of sampling indices is
 proportional to the size of the corresponding value. Does not do any checks on A.
 """
-sampleindices(A::AbstractMatrix, s::Int) = Tuple.(sample(CartesianIndices(A),
-    Weights(vec(A), sum(A)), s,
-    replace = true))
+sampleindices(rng::AbstractRNG, A::AbstractMatrix, s::Int) =
+    Tuple.(_sample_weighted(rng, CartesianIndices(A), vec(A), s))
 
 """
-sampleindices(K::AbstractKroneckerProduct, s::Int)
+    sampleindices([rng::AbstractRNG,] K::AbstractKroneckerProduct, s::Int)
 
 Samples the indices from an `AbstractKroneckerProduct`. Probability of
 sampling indices is proportional to the size of the corresponding value.
 Does not do any checks on A.
 """
-function sampleindices(K::AbstractKroneckerProduct, s::Int)
+function sampleindices(rng::AbstractRNG, K::AbstractKroneckerProduct, s::Int)
     A, B = getmatrices(K)
     p, q = size(B)
-    indicesA = sampleindices(A, s)
-    indicesB = sampleindices(B, s)
+    indicesA = sampleindices(rng, A, s)
+    indicesB = sampleindices(rng, B, s)
     indices = similar(indicesA)
     for (o, (Ia, Ib)) in enumerate(zip(indicesA, indicesB))
         (i, j), (k, l) = Ia, Ib
@@ -84,19 +98,23 @@ function sampleindices(K::AbstractKroneckerProduct, s::Int)
     return indices
 end
 
+sampleindices(A::AbstractMatrix, s::Int) = sampleindices(default_rng(), A, s)
+
 """
-    fastsample(P::AbstractKroneckerProduct)
+    fastsample([rng::AbstractRNG,] P::AbstractKroneckerProduct)
 
 Uses the heuristic sampling from Leskovec et al. (2008) to sample a large
 Kronecker graph.
 """
-function fastsample(P::AbstractKroneckerProduct)
+function fastsample(rng::AbstractRNG, P::AbstractKroneckerProduct)
     @assert isprob(P) throw(DomainError(
         "All values of K should be between 0 and 1"))
     G = spzeros(Bool, size(P)...)
     n = Int(round(sum(P)))  # expected number of edges
-    for (i, j) in sampleindices(P, n)
+    for (i, j) in sampleindices(rng, P, n)
         @inbounds G[i, j] = true
     end
     return G
 end
+
+fastsample(P::AbstractKroneckerProduct) = fastsample(default_rng(), P)

--- a/src/kroneckergraphs.jl
+++ b/src/kroneckergraphs.jl
@@ -22,7 +22,7 @@ using Random: AbstractRNG, default_rng, rand!
 Test if a matrix can be interpeted as a probability matrix, i.e., all elements
 are between 0 and 1.
 """
-isprob(A::AbstractArray) = all(0 .<= A .<= 1)
+isprob(A::AbstractArray) = all(a->0 ≤ a ≤ 1, A)
 
 """
     isprob(K::AbstractKroneckerProduct)
@@ -30,7 +30,7 @@ isprob(A::AbstractArray) = all(0 .<= A .<= 1)
 Test if a Kronecker product can be interpeted as a probability matrix,
 i.e., all elements are between 0 and 1.
 """
-function isprob(K::AbstractKroneckerProduct)
+@inline function isprob(K::AbstractKroneckerProduct)
     A, B = getmatrices(K)
     return isprob(A) && isprob(B)
 end
@@ -59,8 +59,8 @@ back to subscripts) and update `rows`/`cols` Horner-style, i.e.
 `i ← (i - 1)m + i_factor`.
 """
 function _accumulate_indices!(rows::Vector{Int}, cols::Vector{Int},
-        cw::AbstractVector, is::Vector{Int}, js::Vector{Int},
-        u::Vector{Float64}, m::Int, n::Int)
+    cw::AbstractVector, is::Vector{Int}, js::Vector{Int},
+    u::Vector{Float64}, m::Int, n::Int)
     total = last(cw)
     @inbounds for o in eachindex(rows, cols, u)
         idx = _findfirstweight(cw, u[o] * total)

--- a/src/kroneckergraphs.jl
+++ b/src/kroneckergraphs.jl
@@ -14,7 +14,7 @@ Retrieved from https://cs.stanford.edu/~jure/pubs/kronecker-jmlr10.pdf
 =#
 
 using SparseArrays: spzeros
-using Random: AbstractRNG, default_rng
+using Random: AbstractRNG, default_rng, rand!
 
 """
     isprob(A::AbstractArray)
@@ -45,7 +45,39 @@ function _sample_weighted(rng::AbstractRNG, items, weights, s::Int)
     cw = cumsum(weights)
     total = last(cw)
     total > 0 || throw(ArgumentError("weights must have a positive sum"))
-    return [items[searchsortedfirst(cw, rand(rng) * total)] for _ in 1:s]
+    return [items[searchsortedfirst(cw, u * total)] for u in rand(rng, s)]
+end
+
+"""
+    _accumulate_indices!(rows, cols, cw, is, js, u, m, n)
+
+Fold one Kronecker factor into the running global indices: draw an entry of
+the `m × n` factor for each uniform variate in `u` (via its cumulative weights
+`cw` over the vectorised factor, with `is`/`js` mapping linear factor indices
+back to subscripts) and update `rows`/`cols` Horner-style, i.e.
+`i ← (i - 1)m + i_factor`.
+"""
+function _accumulate_indices!(rows::Vector{Int}, cols::Vector{Int},
+        cw::AbstractVector, is::Vector{Int}, js::Vector{Int},
+        u::Vector{Float64}, m::Int, n::Int)
+    total = last(cw)
+    @inbounds for o in eachindex(rows, cols, u)
+        idx = _findfirstweight(cw, u[o] * total)
+        rows[o] = (rows[o] - 1) * m + is[idx]
+        cols[o] = (cols[o] - 1) * n + js[idx]
+    end
+    return nothing
+end
+
+# For the small factors typical of Kronecker graph seeds, a linear scan beats
+# the branchy generic binary search; fall back to the latter for large factors.
+@inline function _findfirstweight(cw::AbstractVector, t)
+    length(cw) > 16 && return searchsortedfirst(cw, t)
+    idx = 1
+    @inbounds while cw[idx] < t
+        idx += 1
+    end
+    return idx
 end
 
 """
@@ -86,16 +118,23 @@ sampling indices is proportional to the size of the corresponding value.
 Does not do any checks on A.
 """
 function sampleindices(rng::AbstractRNG, K::AbstractKroneckerProduct, s::Int)
-    A, B = getmatrices(K)
-    p, q = size(B)
-    indicesA = sampleindices(rng, A, s)
-    indicesB = sampleindices(rng, B, s)
-    indices = similar(indicesA)
-    for (o, (Ia, Ib)) in enumerate(zip(indicesA, indicesB))
-        (i, j), (k, l) = Ia, Ib
-        @inbounds indices[o] = ((i - 1) * p + k, (j - 1) * q + l)
+    rows = ones(Int, s)
+    cols = ones(Int, s)
+    u = Vector{Float64}(undef, s)
+    prev, cw, is, js = nothing, nothing, nothing, nothing
+    for A in getallfactors(K)
+        m = size(A, 1)
+        if A !== prev  # a KroneckerPower repeats one factor: reuse its weights
+            cw = cumsum(vec(A))
+            last(cw) > 0 || throw(ArgumentError("factors must have a positive sum"))
+            is = [mod1(idx, m) for idx in eachindex(cw)]
+            js = [fld1(idx, m) for idx in eachindex(cw)]
+            prev = A
+        end
+        rand!(rng, u)
+        _accumulate_indices!(rows, cols, cw, is, js, u, size(A)...)
     end
-    return indices
+    return collect(zip(rows, cols))
 end
 
 sampleindices(A::AbstractMatrix, s::Int) = sampleindices(default_rng(), A, s)

--- a/src/kroneckergraphs.jl
+++ b/src/kroneckergraphs.jl
@@ -42,6 +42,7 @@ Draw `s` elements from `items` with replacement, with probabilities
 proportional to `weights` (assumed non-negative).
 """
 function _sample_weighted(rng::AbstractRNG, items, weights, s::Int)
+    any(w -> w < 0, weights) && throw(ArgumentError("weights must be non-negative"))
     cw = cumsum(weights)
     total = last(cw)
     total > 0 || throw(ArgumentError("weights must have a positive sum"))
@@ -88,8 +89,8 @@ naive method. This method has a time complexity in the size of the Kronecker
 product (but is still light in memory use). Consider using `fastsample`.
 """
 function naivesample(rng::AbstractRNG, P::AbstractKroneckerProduct)
-    @assert isprob(P) throw(DomainError(
-        "All values of K should be between 0 and 1"))
+    isprob(P) || throw(DomainError(P,
+        "All values of P should be between 0 and 1"))
     G = spzeros(Bool, size(P)...)
     for I in CartesianIndices(P)
         if P[I] > rand(rng)  # QUESTION: is this the most efficient way?
@@ -125,6 +126,7 @@ function sampleindices(rng::AbstractRNG, K::AbstractKroneckerProduct, s::Int)
     for A in getallfactors(K)
         m = size(A, 1)
         if A !== prev  # a KroneckerPower repeats one factor: reuse its weights
+            any(w -> w < 0, A) && throw(ArgumentError("factors must be non-negative"))
             cw = cumsum(vec(A))
             last(cw) > 0 || throw(ArgumentError("factors must have a positive sum"))
             is = [mod1(idx, m) for idx in eachindex(cw)]
@@ -143,15 +145,23 @@ sampleindices(A::AbstractMatrix, s::Int) = sampleindices(default_rng(), A, s)
     fastsample([rng::AbstractRNG,] P::AbstractKroneckerProduct)
 
 Uses the heuristic sampling from Leskovec et al. (2008) to sample a large
-Kronecker graph.
+Kronecker graph: edges are drawn proportionally to their probability until the
+expected number of edges `round(Int, sum(P))` is reached, re-sampling any
+duplicates (collisions) along the way.
 """
 function fastsample(rng::AbstractRNG, P::AbstractKroneckerProduct)
-    @assert isprob(P) throw(DomainError(
-        "All values of K should be between 0 and 1"))
+    isprob(P) || throw(DomainError(P,
+        "All values of P should be between 0 and 1"))
     G = spzeros(Bool, size(P)...)
-    n = Int(round(sum(P)))  # expected number of edges
-    for (i, j) in sampleindices(rng, P, n)
-        @inbounds G[i, j] = true
+    n = round(Int, sum(P))  # expected number of edges
+    added = 0
+    while added < n
+        for (i, j) in sampleindices(rng, P, n - added)
+            if !G[i, j]
+                G[i, j] = true
+                added += 1
+            end
+        end
     end
     return G
 end

--- a/src/names.jl
+++ b/src/names.jl
@@ -1,19 +1,8 @@
-using NamedDims
+# Helpers to combine dimension names of Kronecker factors, e.g. :i and :j
+# into :iᵡj. They act on plain symbols and tuples, so they live in the package
+# proper; the methods that dispatch on NamedDimsArray are defined in the
+# package extension `ext/KroneckerNamedDimsExt.jl`.
 
-# Re-wrap with names:
-kronecker(A::NamedDimsArray{L1}, B::NamedDimsArray{L2}) where {L1,L2} =
-    NamedDimsArray(KroneckerProduct(parent(A), parent(B)), kron_names(L1, L2))
-
-kronecker(A::NamedDimsArray{L}, B::AbstractMatrix) where {L} =
-    NamedDimsArray(KroneckerProduct(parent(A), B), kron_names(L, (:_, :_)))
-kronecker(A::AbstractMatrix, B::NamedDimsArray{L}) where {L} =
-    NamedDimsArray(KroneckerProduct(A, parent(B)), kron_names((:_, :_), L))
-
-# Power
-kronecker(A::NamedDimsArray{L}, p::Int) where {L} =
-    NamedDimsArray(kronecker(parent(A), p), kron_names(L, Val(p)))
-
-# Finding the names
 kron_names(left::Tuple, right::Tuple) = map(_join, left, right)
 
 _join(i::Symbol, j::Symbol) = _join(Val(i), Val(j))
@@ -21,17 +10,3 @@ _join(i::Symbol, j::Symbol) = _join(Val(i), Val(j))
 
 kron_names(L::Tuple, ::Val{1}) = L
 kron_names(L::Tuple, ::Val{p}) where {p} = kron_names(kron_names(L, L), Val(p - 1))
-
-# Disambiguation between NamedDims' `*` methods (which dispatch on
-# NamedDimsArray operands) and the Kronecker vec-trick methods. The type
-# patterns mirror the signatures in NamedDims/src/functions_math.jl.
-const NamedVector = NamedDimsArray{L,T,1,A} where {L,T,A<:AbstractVector{T}}
-
-Base.:*(K::GeneralizedKroneckerProduct, v::NamedVector) = K * parent(v)
-Base.:*(K::IndexedKroneckerProduct, v::NamedVector) = K * parent(v)
-Base.:*(K::KroneckerDiagonal, v::NamedVector) = K * parent(v)
-
-Base.:*(K::GeneralizedKroneckerProduct, M::NamedDimsArray{L,T,2,A}) where {L,T,A<:AbstractMatrix{T}} =
-    NamedDimsArray(K * parent(M), (:_, last(L)))
-Base.:*(M::NamedDimsArray{L,T,2,A}, K::GeneralizedKroneckerProduct) where {L,T,A<:AbstractMatrix{T}} =
-    NamedDimsArray(parent(M) * K, (first(L), :_))

--- a/src/vectrick.jl
+++ b/src/vectrick.jl
@@ -242,6 +242,13 @@ function LinearAlgebra.:\(K::AbstractKroneckerProduct, v::AbstractMatrix)
     return ldiv!(Matrix{promote_type(eltype(v), eltype(K))}(undef, last(size(K)), last(size(v))), K, v)
 end
 
+"""
+    sum(K::AbstractKroneckerProduct; dims::Union{Nothing,Int} = nothing)
+
+Compute the sum of the elements of a Kronecker product. If `dims` is given,
+sum over that dimension, returning a lazy Kronecker product of the summed
+factors.
+"""
 function Base.sum(K::AbstractKroneckerProduct; dims::Union{Nothing,Int} = nothing)
     A, B = getmatrices(K)
     if dims === nothing

--- a/test/testkroneckergraphs.jl
+++ b/test/testkroneckergraphs.jl
@@ -26,6 +26,9 @@
           # exact sample does not always generate this, so don't test
           #@test G[9, 1]  # probability of 1
           @test !G[2, 5]  # probability of 0
+          # collisions are re-sampled, so the number of edges is exactly the
+          # expected edge count of the probability matrix
+          @test sum(G) == round(Int, sum(P))
     end
 
     @testset "helpers" begin
@@ -83,6 +86,8 @@
           freqs = [count(==(i), draws) / n for i in 1:3]
           @test all(abs.(freqs .- weights) .< 0.01)
           @test_throws ArgumentError Kronecker._sample_weighted(rng, 1:3, zeros(3), 5)
+          @test_throws ArgumentError Kronecker._sample_weighted(rng, 1:3, [0.5, -0.1, 0.6], 5)
+          @test_throws ArgumentError sampleindices(rng, [0.5 -0.1; 0.2 0.4] ⊗ [0.3 0.2; 0.1 0.4], 5)
     end
 
 end

--- a/test/testkroneckergraphs.jl
+++ b/test/testkroneckergraphs.jl
@@ -60,6 +60,21 @@
           @test sampleindices(MersenneTwister(42), P1, 50) == sampleindices(MersenneTwister(42), P1, 50)
     end
 
+    @testset "sampleindices matches the kron distribution" begin
+          rng = MersenneTwister(1)
+          n = 200_000
+          A = [0.5 0.1; 0.2 0.7]
+          B = [0.3 0.6 0.1; 0.2 0.05 0.4]  # rectangular factor
+
+          for (K, W) in ((A ⊗ B, kron(A, B)), (kronecker(A, 3), kron(A, A, A)))
+                counts = zeros(size(K))
+                for (i, j) in sampleindices(rng, K, n)
+                      counts[i, j] += 1
+                end
+                @test all(abs.(counts ./ n .- W ./ sum(W)) .< 0.01)
+          end
+    end
+
     @testset "weighted sampling frequencies" begin
           rng = MersenneTwister(0)
           weights = [0.5, 0.3, 0.2]

--- a/test/testkroneckergraphs.jl
+++ b/test/testkroneckergraphs.jl
@@ -53,4 +53,21 @@
          end
    end
 
+    @testset "seeded sampling is deterministic" begin
+          @test naivesample(MersenneTwister(42), P) == naivesample(MersenneTwister(42), P)
+          @test fastsample(MersenneTwister(42), P) == fastsample(MersenneTwister(42), P)
+          @test sampleindices(MersenneTwister(42), P, 50) == sampleindices(MersenneTwister(42), P, 50)
+          @test sampleindices(MersenneTwister(42), P1, 50) == sampleindices(MersenneTwister(42), P1, 50)
+    end
+
+    @testset "weighted sampling frequencies" begin
+          rng = MersenneTwister(0)
+          weights = [0.5, 0.3, 0.2]
+          n = 100_000
+          draws = Kronecker._sample_weighted(rng, 1:3, weights, n)
+          freqs = [count(==(i), draws) / n for i in 1:3]
+          @test all(abs.(freqs .- weights) .< 0.01)
+          @test_throws ArgumentError Kronecker._sample_weighted(rng, 1:3, zeros(3), 5)
+    end
+
 end


### PR DESCRIPTION
Phase 2 of the modernisation plan: dependency slimming via package extensions, preparing the 0.6.0 release. The package's hard dependencies are now **LinearAlgebra, Random and SparseArrays** only.

## Task 2.1 — NamedDims support moved to a package extension
- New `ext/KroneckerNamedDimsExt.jl` holds all methods dispatching on `NamedDimsArray` (including the `*` disambiguation methods added in Phase 1). NamedDims is now a **weak dependency**.
- The name-joining helpers `kron_names`/`_join` stay in `src/names.jl`: they are pure symbol functions with no NamedDims dependency, and keeping them in the package lets `test/testnames.jl` pass **unchanged** (it references `Kronecker._join` etc.). This is a deliberate small deviation from "delete src/names.jl".
- Verified: `using Kronecker` alone does not load NamedDims; loading NamedDims activates the extension.

## Task 2.2 — StatsBase removed
- Weighted sampling is now an internal `_sample_weighted` (cumsum + `searchsortedfirst`).
- `naivesample`, `fastsample` and `sampleindices` take an optional leading `rng::AbstractRNG` (default `Random.default_rng()`), so Kronecker graph sampling is now **reproducible**. Seeded-determinism and frequency tests added.

## Follow-up fixes on this branch (post-release commit)
- **`fastsample` bug fix (behaviour change):** since the original 2019 implementation, `fastsample` drew `round(sum(P))` indices *with replacement* and collapsed duplicates into a single edge, so sampled graphs systematically had fewer edges than the expected count `sum(P)` (for a small concentrated seed matrix, the analytic collision loss matched the observed deficit exactly). Collisions are now re-sampled as in Leskovec et al. (2008), so the graph contains exactly `round(Int, sum(P))` edges. Termination is guaranteed because `isprob` bounds entries by 1. Graphs sampled with a given seed differ from 0.5.x.
- `_sample_weighted` and `sampleindices` now throw an `ArgumentError` for negative weights (a non-monotone `cumsum` would silently corrupt the search); the `@assert isprob(P) throw(...)` pattern was replaced with explicit throws.
- `isprob` no longer allocates (predicate-based `all`).

## Task 2.3 — Documenter 1.x
- Strict mode with `checkdocs = :exports` and doctests; builds locally with zero warnings.
- Added missing docstrings (`eltype`, `conj`, `sum`, `Eigen + UniformScaling`) and fixed stale `@docs` references (a `mul!` entry that no longer matched any docstring now points at `Kronecker.mul_vec_trick!`).

## Task 2.4 — Version 0.6.0
- `Project.toml` bumped to 0.6.0; CHANGELOG updated with a breaking-changes section (min Julia 1.10, NamedDims now opt-in via extension, StatsBase removed). 0.5.6 was never registered, so going straight to 0.6.0 is clean.
- **After merging**: comment `@JuliaRegistrator register` on the release commit to register 0.6.0 (owner action).

## Benchmarks
The tracked benchmark suite (mul/ldiv paths) is untouched by this phase — only docstrings were added to those files. The one changed runtime path is graph sampling. The first cut (a direct StatsBase replacement) was ~12% slower, so `sampleindices` was reworked: the pairwise recursion (three length-`s` allocations per factor) is now a single flat walk over `getallfactors` with preallocated index arrays, batched uniforms, lookup tables instead of an integer division per draw, and a linear weight scan for small factors. Result: **1.13 ms (master, StatsBase) → 0.69 ms** for 10k draws from a 1024×1024 Kronecker power — ~1.6× faster than before, while gaining seedability. The sampling distribution is unchanged and now pinned by tests comparing empirical index frequencies against the dense `kron` distribution (rectangular product and Kronecker power).

## Tests
Full suite passes: 2070 tests + 11 Aqua quality checks (Aqua now also validates the weakdep/extension setup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

